### PR TITLE
update jdyna mvn repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1894,6 +1894,12 @@
 	         <name>Sonatype Releases Repository</name>
 	         <url>http://oss.sonatype.org/content/repositories/releases/</url>
 	    </repository>
+	    <repository>
+                 <id>jdyna-releases</id>
+                 <name>jdyna Releases Repository</name>
+                 <url>https://github.com/Cineca/mvn-repo/raw/master/releases/</url>
+            </repository>
+
    
    </repositories>
    
@@ -1925,7 +1931,12 @@
 				<checksumPolicy>never</checksumPolicy>
 			</snapshots>
         </pluginRepository>
-        
+	   
+        <pluginRepository>
+            <id>jdyna-releases</id>
+                 <name>jdyna Releases Repository</name>
+                 <url>https://github.com/Cineca/mvn-repo/raw/master/releases/</url>
+        </pluginRepository>
         <pluginRepository>
             <id>sonatype-releases</id>
 	         <name>Sonatype Releases Repository</name>


### PR DESCRIPTION
jdyna and cilea repositories added

It solves the following error while compiling:

[ERROR] Failed to execute goal on project xmlui: Could not resolve dependencies for project org.dspace.modules:xmlui:war:CRIS-5.6.2-SNAPSHOT: The following artifacts could not be resolved: org.jdyna:jdyna-web-api:jar:5.7, it.cilea:commons-cilea-webapi:jar:2.2, org.jdyna:jdyna-webmvc-api:jar:5.7, org.jdyna:jdyna-webmvc-webapp:war:5.7: Could not find artifact org.jdyna:jdyna-web-api:jar:5.7 in sonatype-releases (http://oss.sonatype.org/content/repositories/releases/) -> [Help 1]
