### PR TITLE
do not show claim button if the researcher profile already has an owner

### DIFF
--- a/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/researcherDetailsPage.jsp
+++ b/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/researcherDetailsPage.jsp
@@ -315,7 +315,7 @@
 				</c:if>
 
 				
-				<c:if test="${claim && !admin && researcher.epersonID != userID}" >
+				<c:if test="${claim && !admin && empty researcher.epersonID}" >
 				<div class="btn-group">				
 				<c:choose>				
 					<c:when test="${!empty researcher.email.value && empty researcher.epersonID && !userHasRP}">


### PR DESCRIPTION
The condition to show the claim button for a researcherProfile was to check
* if claiming is enabled in cris config
* if the user is not an admin user
* if the owner of the researcherProfile is not the user, who is currently logged in

I think, the last check is obsolete. Instead it should get checked, if the profile has an owner at at all. If it is already linked to an eperson, the claim button should not get displayed at all, in my opinion.

This PR changes this behavior.