### PR TITLE
relaxes claiming check to use orcid if it exists, 

### DIFF
--- a/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/researcherDetailsPage.jsp
+++ b/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/researcherDetailsPage.jsp
@@ -318,7 +318,7 @@
 				<c:if test="${claim && !admin && researcher.epersonID != userID}" >
 				<div class="btn-group">				
 				<c:choose>				
-					<c:when test="${!empty researcher.email.value && empty researcher.epersonID && !userHasRP}">
+					<c:when test="${(!empty researcher.email.value || !empty anagraficaObject.anagrafica4view['orcid']) && empty researcher.epersonID && !userHasRP}">
 						<span id="claim-rp" class="btn btn-primary"><i class="fa fa-user"></i>&nbsp;<fmt:message key="jsp.cris.detail.info.claimrp"/></span>
 					</c:when>
 					<c:otherwise>


### PR DESCRIPTION
even if no email address is provided.

To claim a RP against ORCID an eMail address must be provided in the researcher profile. This is not necessarily the case. If an ORCID is present, it should also be possible to claim the RP with it.