### PR TITLE
introduces new config option to set the default status of manually cr…

### DIFF
--- a/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/json/MyRPJSONController.java
+++ b/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/json/MyRPJSONController.java
@@ -65,10 +65,9 @@ public class MyRPJSONController extends MultiActionController
         if (rp == null)
         {
             rp = new ResearcherPage();
-            String newRpStatus = ConfigurationManager.getProperty("cris","rp.profile.new.status");
-            if (newRpStatus.equals("true")) {
-                rp.setStatus(true);
-            }
+            String newRpStatus = ConfigurationManager.getBooleanProperty("cris","rp.profile.new.status", false);
+            rp.setStatus(newRpStatus);
+
             EPerson currentUser = getCurrentUser(request);
 			rp.setEpersonID(currentUser.getID());
             

--- a/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/json/MyRPJSONController.java
+++ b/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/json/MyRPJSONController.java
@@ -32,6 +32,7 @@ import org.dspace.app.cris.util.ResearcherPageUtils;
 import org.dspace.app.webui.util.UIUtil;
 import org.dspace.content.Metadatum;
 import org.dspace.core.Context;
+import org.dspace.core.ConfigurationManager;
 import org.dspace.eperson.EPerson;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.AbstractController;
@@ -64,6 +65,10 @@ public class MyRPJSONController extends MultiActionController
         if (rp == null)
         {
             rp = new ResearcherPage();
+            String newRpStatus = ConfigurationManager.getProperty("cris","rp.profile.new.status");
+            if (newRpStatus.equals("true")) {
+                rp.setStatus(true);
+            }
             EPerson currentUser = getCurrentUser(request);
 			rp.setEpersonID(currentUser.getID());
             

--- a/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/json/MyRPJSONController.java
+++ b/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/json/MyRPJSONController.java
@@ -65,7 +65,7 @@ public class MyRPJSONController extends MultiActionController
         if (rp == null)
         {
             rp = new ResearcherPage();
-            String newRpStatus = ConfigurationManager.getBooleanProperty("cris","rp.profile.new.status", false);
+            Boolean newRpStatus = ConfigurationManager.getBooleanProperty("cris","rp.profile.new.status", false);
             rp.setStatus(newRpStatus);
 
             EPerson currentUser = getCurrentUser(request);

--- a/dspace/config/modules/cris.cfg
+++ b/dspace/config/modules/cris.cfg
@@ -6,6 +6,9 @@ navbar.cris-entities = publications,researcherprofiles,orgunits,fundings
 
 #Set true if only admin can change the status
 #rp.changestatus.admin = false
+## Status of a new manually created researcher profile
+## Set this to true, if you want the newly created profile to be public by default
+#rp.profile.new.status = true
 
 applicationServiceCache.enabled = true
 applicationServiceCache.max-in-memory-objects = 1000


### PR DESCRIPTION
…eated researcher profiles

The status of newly created researcher profiles is private by default. This PR introduces a configuration option to change that.