### PR TITLE
Fix jersey version for orcid service

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -696,12 +696,12 @@
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-client</artifactId>
-			<version>2.18</version>
+			<version>2.16</version>
 		</dependency>
 		<dependency>
  			<groupId>org.glassfish.jersey.connectors</groupId>
  			<artifactId>jersey-apache-connector</artifactId>
- 			<version>2.18</version>
+ 			<version>2.16</version>
 		</dependency>
 		<dependency>
         	<groupId>com.fasterxml.jackson.jaxrs</groupId>


### PR DESCRIPTION
Jersey Apache Connector throws an exception while using Apache Commons
HttpClient:
java.lang.NoSuchMethodError:
org.apache.http.impl.client.HttpClientBuilder.setConnectionManagerShared
(Z)Lorg/apache/http/
impl/client/HttpClientBuilder;

The problem is that Jersey 2.18 that is used in the project calls the
method that does not exist in Apache Commons HttpClient version 3.1. A
way to fix this is to replace Jersey 2.18 with version 2.16