### PR TITLE
null pointer fix in ItemCrisRefDisplayStrategy.java

### DIFF
--- a/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/util/ItemCrisRefDisplayStrategy.java
+++ b/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/util/ItemCrisRefDisplayStrategy.java
@@ -235,7 +235,7 @@ public class ItemCrisRefDisplayStrategy extends ASimpleDisplayStrategy implement
 		        String icon = "";
 				try {
 					ACrisObject rp = applicationService.getEntityByCrisId(authority);
-					String type = rp.getMetadata(ConfigurationManager.getProperty("cris", "researcher.cris."+publicPath+".ref.display.strategy.metadata.icon"));					
+					String type = (rp == null) ? "deleted" : rp.getMetadata(ConfigurationManager.getProperty("cris", "researcher.cris."+publicPath+".ref.display.strategy.metadata.icon"));					
 					String status = "";
 					if(rp == null || !rp.getStatus()) {
 			             startLink = "&nbsp;";


### PR DESCRIPTION
rp can be a null pointer; if so, rp.getMetadata will throw an
exception and the code below is never reached. This happens for
deleted profiles.

(This is my first PR, it's just a tiny change. Please let me know if I'm doing something wrong.)

It might be better not to show an icon for deleted profiles at all, but this change avoids a null pointer exception and a logged message whenever that happens.