### PR TITLE
Fix final comma in BibTeX export output

### DIFF
--- a/dspace/config/crosswalks/bibtex.template
+++ b/dspace/config/crosswalks/bibtex.template
@@ -1,17 +1,17 @@
 @virtual.reftype.bibtex@{
-	@virtual.uniqueidentifier@,
-	author = {@virtual.bibauthors.author@},
-	title = {@dc.title@},
-	year = {@virtual.date.year@},
-	publisher = {@dc.publisher.name@},
-	address = {@dc.publisher.place@},
-	journal = {@dc.relation.ispartof@},
-	volume = {@dc.relation.volume@},
-	booktitle = {@dc.relation.ispartofbook@},	
-	abstract = {@dc.description.abstract@},
-	keywords = {@virtual.keywords.all@},
-	url = {@dc.identifier.url@},
-	doi = {@dc.identifier.doi@},	
-	pages = {@virtual.fullpage.bibtex@},
-	organization ={@dc.description.sponsorship@}
+	@virtual.uniqueidentifier@@,@
+	author = {@virtual.bibauthors.author@}@,@
+	title = {@dc.title@}@,@
+	year = {@virtual.date.year@}@,@
+	publisher = {@dc.publisher.name@}@,@
+	address = {@dc.publisher.place@}@,@
+	journal = {@dc.relation.ispartof@}@,@
+	volume = {@dc.relation.volume@}@,@
+	booktitle = {@dc.relation.ispartofbook@}@,@	
+	abstract = {@dc.description.abstract@}@,@
+	keywords = {@virtual.keywords.all@}@,@
+	url = {@dc.identifier.url@}@,@
+	doi = {@dc.identifier.doi@}@,@
+	pages = {@virtual.fullpage.bibtex@}@,@
+	organization ={@dc.description.sponsorship@}@,@
 }


### PR DESCRIPTION
dspace-api/src/main/java/org/dspace/content/integration/crosswalks/ReferCrosswalk.java:
Extend to handle "@,@", which is replaced by a comma where it appears
except for the last appearance, where it is deleted.

dspace/config/crosswalks/bibtex.template: Use "@,@" syntax.