### PR TITLE
Update GeoRefAdditionalStatisticsData.java

### DIFF
--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/statistics/GeoRefAdditionalStatisticsData.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/statistics/GeoRefAdditionalStatisticsData.java
@@ -126,9 +126,9 @@ public class GeoRefAdditionalStatisticsData implements
 
         try {
             InetAddress ipAddress = InetAddress.getByName(ip);
-            if(ipAddress.isSiteLocalAddress()) {  // UH omit unrouteable addresses
+            if(ipAddress.isSiteLocalAddress()) { // UH omit unrouteable addresses
             	log.debug("Skipping geolocation lookup for local address "+ip);
-            }else {
+            } else {
 		    CityResponse location = getLocationService().city(ipAddress);
 		    String countryCode = location.getCountry().getIsoCode();
 		    double latitude = location.getLocation().getLatitude();

--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/statistics/GeoRefAdditionalStatisticsData.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/statistics/GeoRefAdditionalStatisticsData.java
@@ -129,42 +129,39 @@ public class GeoRefAdditionalStatisticsData implements
             if(ipAddress.isSiteLocalAddress()) { // omit unrouteable addresses
                 log.debug("Skipping geolocation lookup for local address "+ip);
             } else {
-		    CityResponse location = getLocationService().city(ipAddress);
-		    String countryCode = location.getCountry().getIsoCode();
-		    double latitude = location.getLocation().getLatitude();
-		    double longitude = location.getLocation().getLongitude();
-		    if (!(
-			    "--".equals(countryCode)
-			    && latitude == -180
-			    && longitude == -180)
-		    ) {
-			try {
-			    doc1.addField("continent", LocationUtils
-				.getContinentCode(countryCode));
-			} catch (Exception e) {
-			    System.out
-				.println("COUNTRY ERROR: " + countryCode);
-			}
+	        CityResponse location = getLocationService().city(ipAddress);
+	        String countryCode = location.getCountry().getIsoCode();
+	        double latitude = location.getLocation().getLatitude();
+	        double longitude = location.getLocation().getLongitude();
+	        if (!(
+		    "--".equals(countryCode)
+		    && latitude == -180
+		    && longitude == -180)
+		) {
+		    try {
+		        doc1.addField("continent", LocationUtils
+			.getContinentCode(countryCode));
+	            } catch (Exception e) {
+		        System.out
+			.println("COUNTRY ERROR: " + countryCode);
+	            }
 			doc1.addField("countryCode", countryCode);
 			doc1.addField("city", location.getCity().getName());
 			doc1.addField("latitude", latitude);
 			doc1.addField("longitude", longitude);
 			doc1.addField("location", latitude + ","
 				+ longitude);
-			if (countryCode != null)
-			{
+			if (countryCode != null) {
 			    String continentCode = getCountries2Continent()
 				    .getProperty(countryCode);
-			    if (continentCode == null)
-			    {
+			    if (continentCode == null) {
 				continentCode = getCountries2Continent().getProperty("default");
 			    }
-			    if (continentCode != null)
-			    {
+			    if (continentCode != null) {
 				doc1.addField("continent", continentCode);
+			    }
 			}
-		    }
-	        }
+	            }
             }
         } catch (IOException | GeoIp2Exception e) {
             log.error("Unable to get location of request:  {}", e);
@@ -186,7 +183,7 @@ public class GeoRefAdditionalStatisticsData implements
             DatabaseReader service = null;
             // Get the db file for the location
             String dbPath = ConfigurationManager.getProperty(
-                    SolrLoggerServiceImpl.CFG_USAGE_MODULE, "dbfile");
+                SolrLoggerServiceImpl.CFG_USAGE_MODULE, "dbfile");
             if (dbPath != null) {
                 try {
                     File dbFile = new File(dbPath);

--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/statistics/GeoRefAdditionalStatisticsData.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/statistics/GeoRefAdditionalStatisticsData.java
@@ -126,8 +126,8 @@ public class GeoRefAdditionalStatisticsData implements
 
         try {
             InetAddress ipAddress = InetAddress.getByName(ip);
-            if(ipAddress.isSiteLocalAddress()) { // UH omit unrouteable addresses
-            	log.debug("Skipping geolocation lookup for local address "+ip);
+            if(ipAddress.isSiteLocalAddress()) { // omit unrouteable addresses
+                log.debug("Skipping geolocation lookup for local address "+ip);
             } else {
 		    CityResponse location = getLocationService().city(ipAddress);
 		    String countryCode = location.getCountry().getIsoCode();

--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/statistics/GeoRefAdditionalStatisticsData.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/statistics/GeoRefAdditionalStatisticsData.java
@@ -126,7 +126,7 @@ public class GeoRefAdditionalStatisticsData implements
 
         try {
             InetAddress ipAddress = InetAddress.getByName(ip);
-            if(ipAddress.isSiteLocalAddress()) { // UH omit unrouteable addresses
+            if(ipAddress.isSiteLocalAddress()) {  // UH omit unrouteable addresses
             	log.debug("Skipping geolocation lookup for local address "+ip);
             }else {
 		    CityResponse location = getLocationService().city(ipAddress);

--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/statistics/GeoRefAdditionalStatisticsData.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/statistics/GeoRefAdditionalStatisticsData.java
@@ -126,41 +126,45 @@ public class GeoRefAdditionalStatisticsData implements
 
         try {
             InetAddress ipAddress = InetAddress.getByName(ip);
-            CityResponse location = getLocationService().city(ipAddress);
-            String countryCode = location.getCountry().getIsoCode();
-            double latitude = location.getLocation().getLatitude();
-            double longitude = location.getLocation().getLongitude();
-            if (!(
-                    "--".equals(countryCode)
-                    && latitude == -180
-                    && longitude == -180)
-            ) {
-                try {
-                    doc1.addField("continent", LocationUtils
-                        .getContinentCode(countryCode));
-                } catch (Exception e) {
-                    System.out
-                        .println("COUNTRY ERROR: " + countryCode);
-                }
-                doc1.addField("countryCode", countryCode);
-                doc1.addField("city", location.getCity().getName());
-                doc1.addField("latitude", latitude);
-                doc1.addField("longitude", longitude);
-                doc1.addField("location", latitude + ","
-                        + longitude);
-                if (countryCode != null)
-                {
-                    String continentCode = getCountries2Continent()
-                            .getProperty(countryCode);
-                    if (continentCode == null)
-                    {
-                        continentCode = getCountries2Continent().getProperty("default");
-                    }
-                    if (continentCode != null)
-                    {
-                        doc1.addField("continent", continentCode);
-                    }
-                }
+            if(ipAddress.isSiteLocalAddress()) { // UH omit unrouteable addresses
+            	log.debug("Skipping geolocation lookup for local address "+ip);
+            }else {
+		    CityResponse location = getLocationService().city(ipAddress);
+		    String countryCode = location.getCountry().getIsoCode();
+		    double latitude = location.getLocation().getLatitude();
+		    double longitude = location.getLocation().getLongitude();
+		    if (!(
+			    "--".equals(countryCode)
+			    && latitude == -180
+			    && longitude == -180)
+		    ) {
+			try {
+			    doc1.addField("continent", LocationUtils
+				.getContinentCode(countryCode));
+			} catch (Exception e) {
+			    System.out
+				.println("COUNTRY ERROR: " + countryCode);
+			}
+			doc1.addField("countryCode", countryCode);
+			doc1.addField("city", location.getCity().getName());
+			doc1.addField("latitude", latitude);
+			doc1.addField("longitude", longitude);
+			doc1.addField("location", latitude + ","
+				+ longitude);
+			if (countryCode != null)
+			{
+			    String continentCode = getCountries2Continent()
+				    .getProperty(countryCode);
+			    if (continentCode == null)
+			    {
+				continentCode = getCountries2Continent().getProperty("default");
+			    }
+			    if (continentCode != null)
+			    {
+				doc1.addField("continent", continentCode);
+			}
+		    }
+	        }
             }
         } catch (IOException | GeoIp2Exception e) {
             log.error("Unable to get location of request:  {}", e);


### PR DESCRIPTION
The GeoLite2-City service does not cope well when asked about private adresses. It fails throwing an AddressNotFoundException, which in turn is _not_ catched here(!) (This is another issue this patch does _not_cope with).
This patch uses isSiteLocalAddress() to keep local addresses away from the GeoLite service in the first place.
(see PR#46 patching dspace-5_x_x-cris)