### PR TITLE
Update GeoRefAdditionalStatisticsData.java

### DIFF
--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/statistics/GeoRefAdditionalStatisticsData.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/statistics/GeoRefAdditionalStatisticsData.java
@@ -9,8 +9,8 @@ package org.dspace.app.cris.statistics;
 
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.Properties;
 import java.net.InetAddress;
+import java.util.Properties;
 
 import javax.servlet.http.HttpServletRequest;
 


### PR DESCRIPTION
The GeoLite2-City service does not cope well when asked about private adresses.
This patch uses InetAddress.isSiteLocalAddress() to keep private addresses away from the GeoLite service in the first place, preventing wasted lookups.
The instatiation of InetAddress was skipped after dspace-6_x_x-cris and current master. If this was a performance issue, skip this patch.