### PR TITLE
hiding local addresses from GeoLite2 request

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataLogin.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataLogin.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.statistics.content;
 
 import java.io.IOException;

--- a/dspace-api/src/main/java/org/dspace/statistics/content/filter/StatisticsSolrGenericFilter.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/filter/StatisticsSolrGenericFilter.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.statistics.content.filter;
 
 import org.apache.commons.lang3.StringUtils;

--- a/dspace-api/src/main/java/org/dspace/statistics/content/filter/StatisticsSolrLocationFilter.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/filter/StatisticsSolrLocationFilter.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.statistics.content.filter;
 
 import org.apache.commons.lang3.StringUtils;

--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/statistics/GeoRefAdditionalStatisticsData.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/statistics/GeoRefAdditionalStatisticsData.java
@@ -84,31 +84,35 @@ public class GeoRefAdditionalStatisticsData implements
         }
 
         try {
-            InetAddress ipAddress = InetAddress.getByName(ip);
-            CityResponse location = getLocationService().city(ipAddress);
-            String countryCode = location.getCountry().getIsoCode();
-            double latitude = location.getLocation().getLatitude();
-            double longitude = location.getLocation().getLongitude();
-            if (!(
-                    "--".equals(countryCode)
-                    && latitude == -180
-                    && longitude == -180)
-            ) {
-
-                doc1.addField("countryCode", countryCode);
-                doc1.addField("city", location.getCity().getName());
-                doc1.addField("latitude", latitude);
-                doc1.addField("longitude", longitude);
-                doc1.addField("location", latitude + ","
-                        + longitude);
-                if (countryCode != null)
-                {
-                    try {
-                        doc1.addField("continent", LocationUtils
-                            .getContinentCode(countryCode));
-                    } catch (Exception e) {
-                        System.out
-                            .println("COUNTRY ERROR: " + countryCode);
+            InetAddress ipAddress = InetAddress.getByName(ip); 
+            if(ipAddress.isSiteLocalAddress()) { // omit unrouteable addresses
+            	log.debug("Skipping geolocation lookup for local address "+ip);
+            }else {
+                CityResponse location = getLocationService().city(ipAddress);
+                String countryCode = location.getCountry().getIsoCode();
+                double latitude = location.getLocation().getLatitude();
+                double longitude = location.getLocation().getLongitude();
+                if (!(
+                        "--".equals(countryCode)
+                        && latitude == -180
+                        && longitude == -180)
+                ) {
+    
+                    doc1.addField("countryCode", countryCode);
+                    doc1.addField("city", location.getCity().getName());
+                    doc1.addField("latitude", latitude);
+                    doc1.addField("longitude", longitude);
+                    doc1.addField("location", latitude + ","
+                            + longitude);
+                    if (countryCode != null)
+                    {
+                        try {
+                            doc1.addField("continent", LocationUtils
+                                .getContinentCode(countryCode));
+                        } catch (Exception e) {
+                            System.out
+                                .println("COUNTRY ERROR: " + countryCode);
+                        }
                     }
                 }
             }

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/LoginStatisticsServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/LoginStatisticsServlet.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.app.webui.servlet;
 
 import java.io.IOException;

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/WorkflowStatisticsServlet.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/servlet/WorkflowStatisticsServlet.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.app.webui.servlet;
 
 import java.io.IOException;


### PR DESCRIPTION
The GeoLite2-City service does not cope well when asked about private adresses. It fails throwing an AddressNotFoundException, which in turn is not catched here(!) (This is another issue this patch does _not_cope with).
This patch uses isSiteLocalAddress() to keep local addresses away from the GeoLite service in the first place.

(same PR already sent to dspace-6_x_x-cris)