### PR TITLE
Enable ENTER key in textareas and add suitable rendering of running text (e.g. abstracts, etc.)

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/util/AbbreviateTextDisplayStrategy.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/util/AbbreviateTextDisplayStrategy.java
@@ -1,0 +1,26 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.webui.util;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.log4j.Logger;
+
+public class AbbreviateTextDisplayStrategy extends AUniformDisplayStrategy {
+    /** log4j category */
+    private static Logger log = Logger.getLogger(AbbreviateTextDisplayStrategy.class);
+
+    protected String getDisplayForValue(HttpServletRequest hrq, String value, int itemid) {
+        if (value != null) {
+            value = value.replaceAll("\\r\\n|\\n", "<br/>");
+            return "<div class=\"abbreviate-me\">" + value + "</div>";
+        } else {
+            return "";
+        }
+    }
+}

--- a/dspace-jspui/src/main/webapp/display-item.jsp
+++ b/dspace-jspui/src/main/webapp/display-item.jsp
@@ -133,6 +133,8 @@
 	String crisID = (String)request.getAttribute("crisID");
 %>
 
+<script type='text/javascript' src='<%= request.getContextPath() %>/static/js/abbreviatetext.js'></script>
+
 <% if(pmcEnabled || scopusEnabled || wosEnabled || scholarEnabled || altMetricEnabled) { %>
 <c:set var="dspace.layout.head.last" scope="request">
 <% if(altMetricEnabled) { %> 

--- a/dspace-jspui/src/main/webapp/static/js/abbreviatetext.js
+++ b/dspace-jspui/src/main/webapp/static/js/abbreviatetext.js
@@ -15,13 +15,15 @@ function abbreviate(el, count) {
 		$el.before($shortText);
 
 		let $a = j("<a></a>");
-		$a.toggleClass("fa fa-plus");
+		$a.toggleClass("fa fa-chevron-down");
+        $a.css("cursor", "pointer");
+        $a.css("text-decoration", "none");
 		$a.click(function () {
 			if($el.is(":visible")) $el.stop().slideUp(0);
 			else $el.stop().slideDown(0);
 
-			$a.toggleClass("fa-plus");
-			$a.toggleClass("fa-minus");
+			$a.toggleClass("fa-chevron-down");
+			$a.toggleClass("fa-chevron-up");
 
 			$shortText.toggle();
 		});

--- a/dspace-jspui/src/main/webapp/static/js/abbreviatetext.js
+++ b/dspace-jspui/src/main/webapp/static/js/abbreviatetext.js
@@ -17,8 +17,8 @@ function abbreviate(el, count) {
 		let $a = j("<a></a>");
 		$a.toggleClass("fa fa-plus");
 		$a.click(function () {
-			if($el.is(":visible")) $el.stop().slideUp("fast");
-			else $el.stop().slideDown("fast");
+			if($el.is(":visible")) $el.stop().slideUp(0);
+			else $el.stop().slideDown(0);
 
 			$a.toggleClass("fa-plus");
 			$a.toggleClass("fa-minus");

--- a/dspace-jspui/src/main/webapp/static/js/abbreviatetext.js
+++ b/dspace-jspui/src/main/webapp/static/js/abbreviatetext.js
@@ -1,0 +1,38 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+//  @Author: Cornelius Matějka <cornelius.matejka@uni-bamberg.de>
+
+function abbreviate(el, count) {
+	var $el = j(el);
+	if ($el.html().length > (count + 300)) {
+		let $shortText = j("<div></div>").html(($el.html().substring(0, count)) + "...")
+		$el.before($shortText);
+
+		let $a = j("<a></a>");
+		$a.toggleClass("fa fa-plus");
+		$a.click(function () {
+			if($el.is(":visible")) $el.stop().slideUp("fast");
+			else $el.stop().slideDown("fast");
+
+			$a.toggleClass("fa-plus");
+			$a.toggleClass("fa-minus");
+
+			$shortText.toggle();
+		});
+
+		$el.after($a);
+		$el.hide();
+	}
+}
+
+j(function () {
+	j(".abbreviate-me").each(function() {
+		abbreviate(this, 400);
+	});
+});

--- a/dspace-jspui/src/main/webapp/submit/edit-metadata.jsp
+++ b/dspace-jspui/src/main/webapp/submit/edit-metadata.jsp
@@ -1570,7 +1570,7 @@
 		
 %>
 
-  <form action="<%= request.getContextPath() %>/submit#<%= si.getJumpToField()%>" method="post" name="edit_metadata" id="edit_metadata" onkeydown="return disableEnterKey(event);">
+  <form action="<%= request.getContextPath() %>/submit#<%= si.getJumpToField()%>" method="post" name="edit_metadata" id="edit_metadata">
 
         <jsp:include page="/submit/progressbar.jsp"></jsp:include>
 
@@ -1837,7 +1837,20 @@ j(document).ready(
 		{			
 			<%@ include file="/deduplication/javascriptDeduplication.jsp" %>
 		}		
+
 );
+
+/*
+ * Don't discard 'Enter' input in general, since it
+ * prevents users from inserting a carriage return in
+ * textareas, which might contain several paragraphs
+ * (e.g. description, abstract).
+ */
+j("form").on("keypress", ":input:not(textarea)", function(event) {
+	if (event.keyCode == 13) {
+		event.preventDefault();
+	}
+})
 
 </script>
 <%@ include file="/deduplication/template.jsp" %>

--- a/dspace-jspui/src/main/webapp/submit/review-metadata.jsp
+++ b/dspace-jspui/src/main/webapp/submit/review-metadata.jsp
@@ -186,7 +186,7 @@
                 }
                 else
                 {
-                   row.append(Utils.addEntities(values[i].value));
+                   row.append(Utils.addEntities(values[i].value).replace("&#x0A;", "<br/>"));
                 }
                                 if (isAuthorityControlled)
                 {

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -2030,7 +2030,7 @@ webui.itemdisplay.simple = dc.title, dc.title.alternative, dc.contributor.author
                             dc.identifier.citation, dc.relation(itemcrisref), \
 							dc.relation.publication(itemref), dc.relation.dataset(itemref),\
                             dc.relation.ispartof(itemcrisref), dc.relation.ispartofseries,\
-                            dc.relation.conference(itemcrisref), dc.description.abstract, dc.description, \
+                            dc.relation.conference(itemcrisref), dc.description.abstract(abbreviate), dc.description(abbreviate), \
                             dc.identifier.govdoc, dc.identifier.uri(link), \
                             dc.identifier.isbn, dc.identifier.issn, \
                             dc.identifier.ismn, dc.identifier, dc.identifier.doi(doi), dc.rights
@@ -2040,7 +2040,7 @@ webui.itemdisplay.default = dc.title, dc.title.alternative, dc.contributor.autho
                             dc.identifier.citation, dc.relation(itemcrisref), \
 							dc.relation.publication(itemref), dc.relation.dataset(itemref),\
                             dc.relation.ispartof(itemcrisref), dc.relation.ispartofseries,\
-                            dc.relation.conference(itemcrisref), dc.description.abstract, dc.description, \
+                            dc.relation.conference(itemcrisref), dc.description.abstract(abbreviate), dc.description(abbreviate), \
                             dc.identifier.govdoc, dc.identifier.uri(link), \
                             dc.identifier.isbn, dc.identifier.issn, \
                             dc.identifier.ismn, dc.identifier, dc.identifier.doi(doi), dc.rights


### PR DESCRIPTION
## Rationale
This pull requests addresses DSpace's issue with `textareas`, not allowing the user to insert a line break in a suitable way.
By default DSpace disables the 'ENTER' key to prevent "accidentally submitting a form when the 'Enter' key is pressed".

Running text, e.g. abstracts or descriptions, can only be inserted as continuous text, without sensible structure through paragraphs.

*This pull request does not require additional dependencies.*

## Insert line breaks in `textarea`
This pull request restricts the 'disabled ENTER key' functionality to `inputs` other than `textarea`.

![textarea_form](https://user-images.githubusercontent.com/24757415/49732406-e43bc000-fc7e-11e8-9a26-d9396831de8c.gif)

## Abbreviate running text
Furthermore, running text may clutter the item view, hence abbreviating text, which exceeds a specific length, is reasonable.

![abstract_demo](https://user-images.githubusercontent.com/24757415/49732559-6926d980-fc7f-11e8-8f0f-325957bb974e.gif)

## Properly render running text in the "Verify" step
This pull request also addresses an issue with running text being rendered as one continuous block of text in the submission's "Verify" step, because it turned out, that the user may be confused by this representation.

![screenshot from 2018-12-10 12 47 08](https://user-images.githubusercontent.com/24757415/49732717-c9b61680-fc7f-11e8-9d32-807d07d114e6.png)

