### PR TITLE
Keep context when changing language in DSpace

### DIFF
--- a/dspace-jspui/src/main/webapp/layout/header-default.jsp
+++ b/dspace-jspui/src/main/webapp/layout/header-default.jsp
@@ -261,7 +261,7 @@ window.cookieconsent.initialise({
      {
  %>
         <li><a onclick="javascript:document.repost.locale.value='<%=supportedLocales[i].toString()%>';
-                  document.repost.submit();" href="?locale=<%=supportedLocales[i].toString()%>">
+                  document.repost.submit();" href="javascript:updateURLParam('locale', '<%=supportedLocales[i].toString()%>');">
           <%= LocaleSupport.getLocalizedMessage(pageContext, "jsp.layout.navbar-default.language."+supportedLocales[i].toString()) %>                  
        </a></li>
  <%

--- a/dspace-jspui/src/main/webapp/static/js/custom-functions.js
+++ b/dspace-jspui/src/main/webapp/static/js/custom-functions.js
@@ -94,3 +94,20 @@ jQuery(document).ready(function($){
 		$(this).find('.panel-heading > .panel-title').append(controllerDiv);
 	});
 });
+
+/*
+ * Add/Update GET parameter of URL
+ */
+function updateURLParam(name, value) {
+ var href = window.location.href;
+ var regex = new RegExp("[&\\?]" + name + "=");
+ if(regex.test(href)) {
+	 regex = new RegExp("([&\\?])" + name + "=[^&]*");
+	 window.location.href = href.replace(regex, "$1" + name + "=" + value);
+ } else if(href.indexOf("?") > -1) {
+	 window.location.href = href + "&" + name + "=" + value;
+ } else {
+	 window.location.href = href + "?" + name + "=" + value;
+ }
+}
+


### PR DESCRIPTION
# Rationale
This pull request addresses an issue with _when changing the language in DSpace, already existing GET params are dismissed:_ https://github.com/4Science/DSpace/blob/d22e8189cb7fa572a562a7ed78cf0c52c34976e2/dspace-jspui/src/main/webapp/layout/header-default.jsp#L264

This leads to odd behaviour, since it dismisses current search results, etc.. The implemented functionality addresses this problem by keeping already existing GET params and adding/updating only the `locale` param.

![search_locale](https://user-images.githubusercontent.com/24757415/49792619-80bf9a00-fd33-11e8-9d67-3b7022c4d002.gif)

This functionality can be used with arbitrary params, but is currently only implemented for switching language.