### PR TITLE
Add confirmation before deleting CRIS/JDynA items

### DIFF
--- a/dspace-jspui/src/main/webapp/layout/header-submission.jsp
+++ b/dspace-jspui/src/main/webapp/layout/header-submission.jsp
@@ -85,6 +85,7 @@
 	<script type='text/javascript' src='<%= request.getContextPath() %>/static/js/jquery/jquery-ui-1.11.4.min.js'></script>
 	<script type='text/javascript' src='<%= request.getContextPath() %>/static/js/bootstrap/bootstrap.min.js'></script>
 	<script type="text/javascript" src="<%= request.getContextPath() %>/js/tmpl.min.js"></script>
+	<script type='text/javascript' src='<%= request.getContextPath() %>/static/js/custom-functions.js'></script>
 	<script type="text/javascript" src="<%= request.getContextPath() %>/js/jquery.dataTables.min.js"></script>
 	<script type="text/javascript" src="<%= request.getContextPath() %>/js/dataTables.bootstrap.min.js"></script>
 	<script type="text/javascript" src="<%= request.getContextPath() %>/js/dataTables.buttons.min.js"></script>

--- a/dspace-jspui/src/main/webapp/static/js/custom-functions.js
+++ b/dspace-jspui/src/main/webapp/static/js/custom-functions.js
@@ -93,4 +93,26 @@ jQuery(document).ready(function($){
 		controllerDiv.append(nextArrow);
 		$(this).find('.panel-heading > .panel-title').append(controllerDiv);
 	});
+    addConfirmationBeforeAnyDeleteAction();
 });
+
+/*
+ * Adds an event listener to any button/link that potentially deletes
+ * items, e.g. CRIS items, boxes, tabs, etc.
+ */
+function addConfirmationBeforeAnyDeleteAction() {
+  function addConfirmation() {
+    this.addEventListener('click', function(event) {
+      event.preventDefault();
+      var choice = confirm("Are you sure you want delete this item?");
+      if (choice) window.location.href = this.getAttribute('href');
+    });
+  }
+
+  // CRIS items, like RPs, OrgUnits, Projects, etc.
+  j('[id^=delete]').each(addConfirmation);
+
+  // JDynA items, like tabs, boxes, etc.
+  j('.jdynaremovebutton').each(addConfirmation);
+}
+


### PR DESCRIPTION
# Rationale
The basic design of the administrative panel of DSpace CRIS might increase unintentional deletion of CRIS/JDynA items (RPs, OrgUnits, Boxes, Tabs, etc.), since there's no confirmation and buttons are inappropriate arranged. There's merely a gap between editing or deleting an existing box/tab.
This pull request adds a simple yet effective confirmation dialog in front of every* button/link, which deletes an item.

![delete_confirm](https://user-images.githubusercontent.com/24757415/49800109-fda83f00-fd46-11e8-98bc-7a1da2e652f2.gif)

The confirmation applies to every button/link with `[id^=delete]` (CRIS entities) or `.jdynaremovebutton` (JDynA entities).


*as far as I could identify