### PR TITLE
Fix ineffective 'dynaClear' within surrounding <div>s of nested fields

### DIFF
--- a/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/doDetailsPage.jsp
+++ b/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/doDetailsPage.jsp
@@ -103,6 +103,18 @@
 							});		
 						};
 						var postfunction = function(){
+
+							/*
+							 * Fix ineffective dynaClear within surrounding divs of
+							 * nested fields:
+							 * It checks if the response contains the dynaClear element,
+							 * which indicates the 'New Line' option is checked for this
+							 * field, and appends another one to the surrounding divs.
+							 */
+							if(j(data).find('.dynaClear').length) {
+								j('#viewnested_'+id).after("<div class=\"dynaClear\">&nbsp;</div>");
+							}
+
 							j('#nested_'+id+'_next').click(
 									function() {
 								    	ajaxFunction(parseInt(j('#nested_'+id+"_pageCurrent").html())+1);

--- a/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/jdyna/doDataEditForm.jsp
+++ b/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/jdyna/doDataEditForm.jsp
@@ -181,6 +181,18 @@
 						});		
 					};
 					var postfunction = function(){
+
+						/*
+						 * Fix ineffective dynaClear within surrounding divs of
+						 * nested fields:
+						 * It checks if the response contains the dynaClear element,
+						 * which indicates the 'New Line' option is checked for this
+						 * field, and appends another one to the surrounding divs.
+						 */
+						if(j(data).find('.dynaClear').length) {
+							j('#viewnested_'+id).after("<div class=\"dynaClear\">&nbsp;</div>");
+						}
+
 						j('#viewnested_'+id+' .nested_edit_button').parent().parent().mouseover(function(){
 							j(this).toggleClass('ui-state-hover');
 						});

--- a/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/jdyna/ouDataEditForm.jsp
+++ b/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/jdyna/ouDataEditForm.jsp
@@ -181,6 +181,18 @@
 						});		
 					};
 					var postfunction = function(){
+
+						/*
+						 * Fix ineffective dynaClear within surrounding divs of
+						 * nested fields:
+						 * It checks if the response contains the dynaClear element,
+						 * which indicates the 'New Line' option is checked for this
+						 * field, and appends another one to the surrounding divs.
+						 */
+						if(j(data).find('.dynaClear').length) {
+							j('#viewnested_'+id).after("<div class=\"dynaClear\">&nbsp;</div>");
+						}
+
 						j('#viewnested_'+id+' .nested_edit_button').parent().parent().mouseover(function(){
 							j(this).toggleClass('ui-state-hover');
 						});

--- a/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/jdyna/projectDataEditForm.jsp
+++ b/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/jdyna/projectDataEditForm.jsp
@@ -180,6 +180,18 @@
 							});		
 						};
 						var postfunction = function(){
+
+							/*
+							 * Fix ineffective dynaClear within surrounding divs of
+							 * nested fields:
+							 * It checks if the response contains the dynaClear element,
+							 * which indicates the 'New Line' option is checked for this
+							 * field, and appends another one to the surrounding divs.
+							 */
+							if(j(data).find('.dynaClear').length) {
+								j('#viewnested_'+id).after("<div class=\"dynaClear\">&nbsp;</div>");
+							}
+
 							j('#viewnested_'+id+' .nested_edit_button').parent().parent().mouseover(function(){
 								j(this).toggleClass('ui-state-hover');
 							});

--- a/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/jdyna/rpDataEditForm.jsp
+++ b/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/jdyna/rpDataEditForm.jsp
@@ -181,6 +181,18 @@
 							});		
 						};
 						var postfunction = function(){
+
+							/*
+							 * Fix ineffective dynaClear within surrounding divs of
+							 * nested fields:
+							 * It checks if the response contains the dynaClear element,
+							 * which indicates the 'New Line' option is checked for this
+							 * field, and appends another one to the surrounding divs.
+							 */
+							if(j(data).find('.dynaClear').length) {
+								j('#viewnested_'+id).after("<div class=\"dynaClear\">&nbsp;</div>");
+							}
+
 							j('#viewnested_'+id+' .nested_edit_button').parent().parent().mouseover(function(){
 								j(this).toggleClass('ui-state-hover');
 							});

--- a/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/ouDetailsPage.jsp
+++ b/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/ouDetailsPage.jsp
@@ -101,6 +101,18 @@
 							});		
 						};
 						var postfunction = function(){
+
+							/*
+							 * Fix ineffective dynaClear within surrounding divs of
+							 * nested fields:
+							 * It checks if the response contains the dynaClear element,
+							 * which indicates the 'New Line' option is checked for this
+							 * field, and appends another one to the surrounding divs.
+							 */
+							if(j(data).find('.dynaClear').length) {
+								j('#viewnested_'+id).after("<div class=\"dynaClear\">&nbsp;</div>");
+							}
+
 							j('#nested_'+id+'_next').click(
 									function() {
 								    	ajaxFunction(parseInt(j('#nested_'+id+"_pageCurrent").html())+1);

--- a/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/projectDetailsPage.jsp
+++ b/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/projectDetailsPage.jsp
@@ -101,6 +101,18 @@
 							});		
 						};
 						var postfunction = function(){
+
+							/*
+							 * Fix ineffective dynaClear within surrounding divs of
+							 * nested fields:
+							 * It checks if the response contains the dynaClear element,
+							 * which indicates the 'New Line' option is checked for this
+							 * field, and appends another one to the surrounding divs.
+							 */
+							if(j(data).find('.dynaClear').length) {
+								j('#viewnested_'+id).after("<div class=\"dynaClear\">&nbsp;</div>");
+							}
+
 							j('#nested_'+id+'_next').click(
 									function() {
 								    	ajaxFunction(parseInt(j('#nested_'+id+"_pageCurrent").html())+1);	

--- a/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/researcherDetailsPage.jsp
+++ b/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/researcherDetailsPage.jsp
@@ -141,6 +141,18 @@
 							});		
 						};
 						var postfunction = function(){
+
+							/*
+							 * Fix ineffective dynaClear within surrounding divs of
+							 * nested fields:
+							 * It checks if the response contains the dynaClear element,
+							 * which indicates the 'New Line' option is checked for this
+							 * field, and appends another one to the surrounding divs.
+							 */
+							if(j(data).find('.dynaClear').length) {
+								j('#viewnested_'+id).after("<div class=\"dynaClear\">&nbsp;</div>");
+							}
+
 							j('#nested_'+id+'_next').click(
 									function() {
 								    	ajaxFunction(parseInt(j('#nested_'+id+"_pageCurrent").html())+1);


### PR DESCRIPTION
# Rationale
Currently, the 'New Line' option in nested field definitions does not apply. This is caused by DSpace CRIS, adding additional `<div>`s around JDynA's response, which is composed of two `<div>`s (`.dynaField`, `.dynaClear`), and casts the responsible `dynaClear` element ineffective.

![screenshot from 2018-12-19 12 31 06](https://user-images.githubusercontent.com/24757415/50220120-b39c0a80-0391-11e9-977e-1c3b15b4401d.png)

This pull request addresses this issue. It might not be the cleanest way, but it does not interfere with other functionality and just searches the JDynA response for the `dynaClear` element and adds it to the proper place if it exists.

The comments can be removed if a merge is considered.