### PR TITLE
Add configurable limit to results per page

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfiguration.java
@@ -43,7 +43,7 @@ public class DiscoveryConfiguration implements InitializingBean{
     private DiscoverySortConfiguration searchSortConfiguration;
 
     private int defaultRpp = 10;
-    private int maxRpp = 20;
+    private int maxRpp = -1;
     
     private String id;
     private DiscoveryHitHighlightingConfiguration hitHighlightingConfiguration;
@@ -132,7 +132,7 @@ public class DiscoveryConfiguration implements InitializingBean{
 
     public int getMaxRpp()
     {
-        return maxRpp;
+        return (maxRpp < 0) ? (2 * defaultRpp) : maxRpp;
     }
 
     public void setHitHighlightingConfiguration(DiscoveryHitHighlightingConfiguration hitHighlightingConfiguration) {

--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfiguration.java
@@ -43,6 +43,7 @@ public class DiscoveryConfiguration implements InitializingBean{
     private DiscoverySortConfiguration searchSortConfiguration;
 
     private int defaultRpp = 10;
+    private int maxRpp = 20;
     
     private String id;
     private DiscoveryHitHighlightingConfiguration hitHighlightingConfiguration;
@@ -118,10 +119,20 @@ public class DiscoveryConfiguration implements InitializingBean{
     {
         this.defaultRpp = defaultRpp;
     }
+
+    public void setMaxRpp(int maxRpp)
+    {
+        this.maxRpp = maxRpp;
+    }
     
     public int getDefaultRpp()
     {
         return defaultRpp;
+    }
+
+    public int getMaxRpp()
+    {
+        return maxRpp;
     }
 
     public void setHitHighlightingConfiguration(DiscoveryHitHighlightingConfiguration hitHighlightingConfiguration) {

--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfiguration.java
@@ -43,7 +43,7 @@ public class DiscoveryConfiguration implements InitializingBean{
     private DiscoverySortConfiguration searchSortConfiguration;
 
     private int defaultRpp = 10;
-    private int maxRpp = -1;
+    private int maxRpp = 100;
     
     private String id;
     private DiscoveryHitHighlightingConfiguration hitHighlightingConfiguration;
@@ -132,7 +132,7 @@ public class DiscoveryConfiguration implements InitializingBean{
 
     public int getMaxRpp()
     {
-        return (maxRpp < 0) ? (2 * defaultRpp) : maxRpp;
+        return maxRpp;
     }
 
     public void setHitHighlightingConfiguration(DiscoveryHitHighlightingConfiguration hitHighlightingConfiguration) {

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/discovery/DiscoverUtility.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/discovery/DiscoverUtility.java
@@ -466,7 +466,7 @@ public class DiscoverUtility
             //
             // }
 
-            if (rpp > 0 && rpp < discoveryConfiguration.getMaxRpp())
+            if (rpp > 0 && rpp <= discoveryConfiguration.getMaxRpp())
             {
                 queryArgs.setMaxResults(rpp);
             }

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/discovery/DiscoverUtility.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/discovery/DiscoverUtility.java
@@ -466,9 +466,13 @@ public class DiscoverUtility
             //
             // }
 
-            if (rpp > 0)
+            if (rpp > 0 && rpp < discoveryConfiguration.getMaxRpp())
             {
                 queryArgs.setMaxResults(rpp);
+            }
+            else if (rpp > 0 && rpp > discoveryConfiguration.getMaxRpp())
+            {
+                queryArgs.setMaxResults(discoveryConfiguration.getMaxRpp());
             }
             else
             {

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -365,6 +365,7 @@
 		</property>
 		<!--Default result per page -->
 		<property name="defaultRpp" value="50" />
+		<property name="maxRpp" value="100" />
 		<property name="hitHighlightingConfiguration">		
 			<bean
 				class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
@@ -503,6 +504,7 @@
 		</property>
 		<!--Default result per page -->
 		<property name="defaultRpp" value="50" />
+		<property name="maxRpp" value="100" />
 		<property name="hitHighlightingConfiguration">
 			<bean
 				class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
@@ -711,6 +713,7 @@
 		</property>
 		<!--Default result per page -->
 		<property name="defaultRpp" value="10" />
+		<property name="maxRpp" value="20" />
 		<property name="hitHighlightingConfiguration">
 			<bean
 				class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
@@ -817,6 +820,7 @@
 		</property>
 		<!--Default result per page -->
 		<property name="defaultRpp" value="10" />
+		<property name="maxRpp" value="20" />
 		<property name="hitHighlightingConfiguration">
 			<bean
 				class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
@@ -922,6 +926,7 @@
 		</property>
 		<!--Default result per page -->
 		<property name="defaultRpp" value="10" />
+		<property name="maxRpp" value="20" />
 		<property name="hitHighlightingConfiguration">
 			<bean
 				class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
@@ -1029,6 +1034,7 @@
 		</property>
 		<!--Default result per page -->
 		<property name="defaultRpp" value="10" />
+		<property name="maxRpp" value="20" />
 		<property name="hitHighlightingConfiguration">
 			<bean
 				class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
@@ -1135,6 +1141,7 @@
 		</property>
 		<!--Default result per page -->
 		<property name="defaultRpp" value="10" />
+		<property name="maxRpp" value="20" />
 		<property name="hitHighlightingConfiguration">
 			<bean
 				class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
@@ -1243,6 +1250,7 @@
 		</property>
 		<!--Default result per page -->
 		<property name="defaultRpp" value="50" />
+		<property name="maxRpp" value="100" />
 		<property name="hitHighlightingConfiguration">
 			<bean
 				class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
@@ -1333,6 +1341,7 @@
 		</property>
 		<!--Default result per page -->
 		<property name="defaultRpp" value="50" />
+		<property name="maxRpp" value="100" />
 		<property name="hitHighlightingConfiguration">
 				<bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
 				<property name="metadataFields">
@@ -1434,6 +1443,7 @@
 		</property>
 		<!--Default result per page -->
 		<property name="defaultRpp" value="50" />
+		<property name="maxRpp" value="100" />
 		<property name="hitHighlightingConfiguration">
 				<bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
 				<property name="metadataFields">
@@ -1535,6 +1545,7 @@
 		</property>
 		<!--Default result per page -->
 		<property name="defaultRpp" value="50" />
+		<property name="maxRpp" value="100" />
 		<property name="hitHighlightingConfiguration">
 				<bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
 				<property name="metadataFields">
@@ -1636,6 +1647,7 @@
 		</property>
 		<!--Default result per page -->
 		<property name="defaultRpp" value="50" />
+		<property name="maxRpp" value="100" />
 		<property name="hitHighlightingConfiguration">
 				<bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
 				<property name="metadataFields">


### PR DESCRIPTION
# Rational

When searching for researchers or similar in DSpace CRIS, the user can modify the `rpp` GET parameter and get all results at a single blow.

Even DSpace CRIS instances, which hide the 'Results Per Page' option can be exploited.

I see a major issue here, because this makes DSpace CRIS vulnerable to DOS.
Our instance currently holds around 44000 publications. I've sent a few requests, which requested all publications at once with the method mentioned above and the instance showed an internal server error for several minutes for users visiting the website.

The problem is, that in our case SOLR is overloaded, which gives an internal server error, in other case the connection pool was exhausted, which gives an 503 'Service not available' error.

This pull request adds the option to configure a maximum for 'Results Per Page' to solve this specific problem.