### PR TITLE
Fix flawed 'equals' check when importing cris-configuration.xls

### DIFF
--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/batch/ImportCRISDataModelConfiguration.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/batch/ImportCRISDataModelConfiguration.java
@@ -894,7 +894,7 @@ public class ImportCRISDataModelConfiguration
             Boolean bnewLine = false;
             if (StringUtils.isNotBlank(newLine))
             {
-                bnewLine = bnewLine.equals("y") ? true : false;
+                bnewLine = newLine.equals("y") ? true : false;
             }
 			System.out.println("Writing  " + target + "/" + shortName);
 


### PR DESCRIPTION
## Reason
On import, this small typo causes the `new-line` option to be always set to `false` for nested objects.

Compare line `894` and `897`, which contradict each other.