### PR TITLE
Fix issue: Authorize Edit CrisEntity for users

### DIFF
--- a/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/util/CrisAuthorizeManager.java
+++ b/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/util/CrisAuthorizeManager.java
@@ -76,12 +76,15 @@ public class CrisAuthorizeManager
             {
                 for (PD policy : listPolicySingle)
                 {
-                    String data = object.getMetadata(policy.getShortName());
-                    if (StringUtils.isNotBlank(data))
+                    List<String> policies = object.getMetadataValue(policy.getShortName());
+                    for(String data: policies)
                     {
-                        if (currUser.getID() == Integer.parseInt(data))
+                        if (StringUtils.isNotBlank(data))
                         {
-                            return true;
+                            if (currUser.getID() == Integer.parseInt(data))
+                            {
+                                  return true;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
There is an issue when a user wants to edit a CrisEntity which is allowed to be edited by several users.
Currently only the first users from the authorized list can access the edit mode of a CrisEntity. 
The resaon is that only one String data object has been created and not a list of policies as in *listPolicyGroup*.

The pr creates a list and iterates over each data object to check if the current userID matches the data object.