### PR TITLE
Include taglib (http://java.sun.com/jsp/jstl/core) in main.jsp.

### DIFF
--- a/dspace-jspui/src/main/webapp/mydspace/main.jsp
+++ b/dspace-jspui/src/main/webapp/mydspace/main.jsp
@@ -24,6 +24,8 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt"
     prefix="fmt" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core"
+    prefix="c" %>
 
 <%@ taglib uri="http://www.dspace.org/dspace-tags.tld" prefix="dspace" %>
 


### PR DESCRIPTION
## Rational

Taglib (http://java.sun.com/jsp/jstl/core) is not included in `main.jsp` but used to set `dspace.layout.head.last`.
This caused `dspace.layout.head.last` to never be set properly.

This is the source code the browser receives from the server. `<c:set>` was not processed by the servlet.
![Screenshot from 2019-05-08 09:50:02](https://user-images.githubusercontent.com/24757415/57358900-b21f8300-7176-11e9-8cc0-abd0e8e5e17a.png)

Fortunately, no problems emerged because the JavaScript within `<c:set var="dspace.layout.head.last" scrope="request">...</c:set>` could be interpreted without problems by the browser.
But recent changes for our instance, which expanded this JavaScript code, rendered the site unusable, since the servlet consistently chopped off parts of the JavaScript when it became too long before proceeding with the rest of the page.

This PR fixes this issue by importing the respective taglib which was forgotten in https://github.com/4Science/DSpace/commit/eaac4883508d2617c091587822d60b895342f6a0.


