### PR TITLE
To fix locale is null problem

### DIFF
--- a/dspace-jspui/src/main/webapp/submit/edit-metadata.jsp
+++ b/dspace-jspui/src/main/webapp/submit/edit-metadata.jsp
@@ -273,7 +273,7 @@
                    .append("_id\" name=\"").append(fieldInput)
                    .append("\" size=\"").append(String.valueOf(repeatable ? 6 : 1))
                    .append(repeatable ? "\" multiple>\n" :"\">\n");
-                Choices cs = cam.getMatches(fieldName, null, collectionID, 0, 0, null);
+                Choices cs = cam.getMatches(fieldName, null, collectionID, 0, 0, (lcl != null ? lcl.toString() : "en"));
                 // prepend unselected empty value when nothing can be selected.
                 if (!repeatable && cs.defaultSelected < 0 && dcvs.length == 0)
                     sb.append("<option value=\"\"><!-- empty --></option>\n");


### PR DESCRIPTION
When edit item, will have error message

2019-05-14 15:20:19,954 ERROR org.dspace.app.webui.servlet.SubmissionController.doStep(SubmissionController.java:555) @ Error loading step class'org.dspace.submit.step.DescribeStep':
javax.servlet.ServletException: org.apache.jasper.JasperException: java.lang.NullPointerException
	at org.dspace.utils.servlet.DSpaceWebappServletFilter.doFilter(DSpaceWebappServletFilter.java:85)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apache.catalina.core.ApplicationDispatcher.invoke(ApplicationDispatcher.java:728)
	at org.apache.catalina.core.ApplicationDispatcher.processRequest(ApplicationDispatcher.java:470)
	at org.apache.catalina.core.ApplicationDispatcher.doForward(ApplicationDispatcher.java:395)
	at org.apache.catalina.core.ApplicationDispatcher.forward(ApplicationDispatcher.java:316)
	at org.dspace.app.webui.util.JSPManager.showJSP(JSPManager.java:60)
	at org.dspace.app.webui.submit.JSPStepManager.showJSP(JSPStepManager.java:372)
	at org.dspace.app.webui.submit.step.JSPDescribeStep.showEditMetadata(JSPDescribeStep.java:236)
	at org.dspace.app.webui.submit.step.JSPDescribeStep.doPreProcessing(JSPDescribeStep.java:113)
	at org.dspace.app.webui.submit.JSPStepManager.doStepStart(JSPStepManager.java:284)
	at org.dspace.app.webui.submit.JSPStepManager.processStep(JSPStepManager.java:246)
	at org.dspace.app.webui.servlet.SubmissionController.doStep(SubmissionController.java:529)
	at org.dspace.app.webui.servlet.SubmissionController.doNextStep(SubmissionController.java:599)
	at org.dspace.app.webui.servlet.SubmissionController.doStep(SubmissionController.java:545)
	at org.dspace.app.webui.servlet.SubmissionController.doNextStep(SubmissionController.java:599)
	at org.dspace.app.webui.servlet.SubmissionController.doStep(SubmissionController.java:545)
	at org.dspace.app.webui.servlet.SubmissionController.doDSPost(SubmissionController.java:432)
	at org.dspace.app.webui.servlet.DSpaceServlet.processRequest(DSpaceServlet.java:115)
	at org.dspace.app.webui.servlet.DSpaceServlet.doGet(DSpaceServlet.java:67)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:635)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:742)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.dspace.app.webui.filter.RegisteredOnlyFilter.doFilter(RegisteredOnlyFilter.java:66)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.dspace.utils.servlet.DSpaceWebappServletFilter.doFilter(DSpaceWebappServletFilter.java:78)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:198)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:96)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:493)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:140)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:81)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:87)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:342)
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:800)
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:66)
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:806)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1498)
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.apache.jasper.JasperException: java.lang.NullPointerException
	at org.apache.jasper.servlet.JspServletWrapper.handleJspException(JspServletWrapper.java:598)
	at org.apache.jasper.servlet.JspServletWrapper.service(JspServletWrapper.java:514)
	at org.apache.jasper.servlet.JspServlet.serviceJspFile(JspServlet.java:386)
	at org.apache.jasper.servlet.JspServlet.service(JspServlet.java:330)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:742)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)
	at org.dspace.utils.servlet.DSpaceWebappServletFilter.doFilter(DSpaceWebappServletFilter.java:78)
	... 49 more
Caused by: java.lang.NullPointerException
	at org.dspace.content.authority.DCInputAuthority.init(DCInputAuthority.java:113)
	at org.dspace.content.authority.DCInputAuthority.getMatches(DCInputAuthority.java:135)
	at org.dspace.content.authority.ChoiceAuthorityManager.getMatches(ChoiceAuthorityManager.java:292)
	at org.apache.jsp.submit.edit_002dmetadata_jsp.doAuthority(edit_002dmetadata_jsp.java:265)
	at org.apache.jsp.submit.edit_002dmetadata_jsp.doChoiceSelect(edit_002dmetadata_jsp.java:1377)
	at org.apache.jsp.submit.edit_002dmetadata_jsp._jspService(edit_002dmetadata_jsp.java:2184)
	at org.apache.jasper.runtime.HttpJspBase.service(HttpJspBase.java:70)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:742)
	at org.apache.jasper.servlet.JspServletWrapper.service(JspServletWrapper.java:476)
	... 58 more

So this is to fix the locale is null problem