### PR TITLE
Display own/shared private CRIS entities of current user in /mydspace

### DIFF
--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -2251,8 +2251,11 @@ jsp.layout.navbar.entity.edit = Edit entity
 
 jsp.cris.detail.navigation-menu-heading = CRIS Entity navigation
 jsp.search.results.cris.rp = Researcher profiles
+jsp.search.results.cris.crisrp = Researcher profile
 jsp.search.results.cris.project = Projects
+jsp.search.results.cris.crispj = Project
 jsp.search.results.cris.ou = Organization Units
+jsp.search.results.cris.crisou = Organization Unit
 jsp.search.results.cris.dspacecommunity = DSpace Communities
 jsp.search.results.cris.dspacecollection = DSpace Collections
 jsp.mydspace.cris.rp-status-change.dialog-active.title = Hide or remove your researcher profile
@@ -2274,6 +2277,11 @@ jsp.mydspace.cris.rp-status-change.remove = Warning: Permanently delete
 jsp.mydspace.cris.rp-status-change.keep-active = Keep the profile public
 jsp.mydspace.cris.rp-status-change.keep-inactive = Keep the profile private
 jsp.mydspace.cris.rp-status-change.keep-undefined = Decide later
+
+jsp.mydspace.cris.privateentities = Private entities
+jsp.mydspace.cris.privateentities.type = Type
+jsp.mydspace.cris.privateentities.name = Name
+jsp.mydspace.cris.privateentities.lastmodified = Last modified
 
 jsp.layout.dspace.detail.fieldset-legend.component.default							= Entities
 jsp.layout.dspace.detail.fieldset-legend.component.all								= All

--- a/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/DynamicObjectDetailsController.java
+++ b/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/DynamicObjectDetailsController.java
@@ -113,7 +113,7 @@ public class DynamicObjectDetailsController
         boolean isAdmin = CrisAuthorizeManager.isAdmin(context,dyn);
         boolean canEdit = isAdmin || CrisAuthorizeManager.canEdit(context, applicationService, EditTabDynamicObject.class, dyn);
         if ((dyn.getStatus() == null || dyn.getStatus().booleanValue() == false)
-                && !isAdmin)
+                && !canEdit)
         {
             
             if (currUser != null

--- a/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/OUDetailsController.java
+++ b/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/OUDetailsController.java
@@ -108,7 +108,7 @@ public class OUDetailsController
         boolean isAdmin = CrisAuthorizeManager.isAdmin(context,ou);
         boolean canEdit = isAdmin || CrisAuthorizeManager.canEdit(context, applicationService, EditTabOrganizationUnit.class, ou);
         if ((ou.getStatus() == null || ou.getStatus().booleanValue() == false)
-                && !isAdmin)
+                && !canEdit)
         {
             
             if (currUser != null

--- a/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/PrivateEntitiesController.java
+++ b/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/PrivateEntitiesController.java
@@ -1,0 +1,169 @@
+package org.dspace.app.webui.cris.controller;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrDocumentList;
+import org.dspace.app.cris.model.ACrisObject;
+import org.dspace.app.cris.model.OrganizationUnit;
+import org.dspace.app.cris.model.Project;
+import org.dspace.app.cris.model.ResearcherPage;
+import org.dspace.app.cris.model.jdyna.EditTabDynamicObject;
+import org.dspace.app.cris.model.jdyna.EditTabOrganizationUnit;
+import org.dspace.app.cris.model.jdyna.EditTabProject;
+import org.dspace.app.cris.model.jdyna.EditTabResearcherPage;
+import org.dspace.app.cris.service.ApplicationService;
+import org.dspace.app.webui.cris.util.CrisAuthorizeManager;
+import org.dspace.app.webui.util.UIUtil;
+import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Context;
+import org.dspace.discovery.SearchService;
+import org.dspace.discovery.SearchServiceException;
+import org.dspace.utils.DSpace;
+import org.springframework.web.servlet.ModelAndView;
+
+import it.cilea.osd.common.controller.BaseAbstractController;
+import it.cilea.osd.jdyna.web.AbstractEditTab;
+import it.cilea.osd.jdyna.web.ITabService;
+
+/**
+ * This SpringMVC controller is used to fetch private CRIS entities of the
+ * current authorized user.
+ * 
+ * @author Cornelius Matějka <cornelius.matejka@uni-bamberg.de>
+ * 
+ */
+@SuppressWarnings("rawtypes")
+public class PrivateEntitiesController extends BaseAbstractController {
+
+	private final ITabService applicationService;
+	private final SearchService searchService;
+	private final Map<Class<ACrisObject>, Integer> configuration;
+
+	public PrivateEntitiesController() {
+
+		DSpace dspace = new DSpace();
+		this.applicationService = dspace.getServiceManager().getServiceByName("applicationService",
+				ApplicationService.class);
+		this.searchService = dspace.getSingletonService(SearchService.class);
+		this.configuration = parseConfiguration();
+
+	}
+
+	@Override
+	protected ModelAndView handleRequestInternal(HttpServletRequest request, HttpServletResponse response)
+			throws Exception {
+
+		Map<String, Object> model = new HashMap<String, Object>();
+
+		Context context = UIUtil.obtainContext(request);
+		List<ACrisObject> privateEntitiesOfCurrentUser = getPrivateEntitiesForCurrentUser(context);
+
+		model.put("privateEntities", privateEntitiesOfCurrentUser);
+
+		return new ModelAndView("privateEntities", model);
+	}
+
+	private Map<Class<ACrisObject>, Integer> parseConfiguration() {
+		/*
+		 * Parse configuration for private entities: '<entity_class>:<entity_typeID>'
+		 * configured in cris.cfg
+		 */
+		Map<Class<ACrisObject>, Integer> configuration = new HashMap<>();
+		for (String st : ConfigurationManager.getProperty("cris", "rp.privateentities").split(",")) {
+			String[] sta = st.split(":");
+			Class<ACrisObject> clazz;
+			int typeID;
+			try {
+				clazz = (Class<ACrisObject>) Class.forName(sta[0].trim());
+				typeID = Integer.parseInt(sta[1].trim());
+				configuration.put(clazz, typeID);
+			} catch (ClassNotFoundException e) {
+				log.error(e);
+			}
+		}
+		return configuration;
+	}
+
+	private List<ACrisObject> getPrivateEntitiesForCurrentUser(Context context) {
+
+		List<ACrisObject> allPrivateEntities = getAllPrivateEntities();
+		List<ACrisObject> myPrivateEntities = new LinkedList<>();
+		try {
+			myPrivateEntities = getMyPrivateEntities(allPrivateEntities, context);
+		} catch (SQLException e) {
+			log.error(e);
+		}
+
+		return myPrivateEntities;
+	}
+
+	private List<ACrisObject> getAllPrivateEntities() {
+
+		List<ACrisObject> privateEntities = new LinkedList<>();
+
+		for (Class<ACrisObject> key : configuration.keySet()) {
+			try {
+				SolrQuery query = new SolrQuery("{!field f=search.resourcetype}" + configuration.get(key));
+				query.setFilterQueries("discoverable: \"false\"");
+				query.setRows(Integer.MAX_VALUE);
+
+				QueryResponse response = this.searchService.search(query);
+
+				SolrDocumentList docList = response.getResults();
+
+				Iterator<SolrDocument> solrDoc = docList.iterator();
+				while (solrDoc.hasNext()) {
+					SolrDocument doc = solrDoc.next();
+					Integer coID = (Integer) doc.getFirstValue("search.resourceid");
+					ACrisObject co = this.applicationService.get(key, coID);
+					if (co != null)
+						privateEntities.add(co);
+				}
+			} catch (SearchServiceException e) {
+				log.error(e);
+			}
+		}
+
+		return privateEntities;
+	}
+
+	private List<ACrisObject> getMyPrivateEntities(List<ACrisObject> privateProjects, Context context)
+			throws SQLException {
+
+		List<ACrisObject> myPrivateEntities = new LinkedList<>();
+
+		for (ACrisObject co : privateProjects) {
+			boolean canEdit = CrisAuthorizeManager.canEdit(context, this.applicationService, getTabClass(co), co);
+			if (canEdit) {
+				myPrivateEntities.add(co);
+			}
+		}
+
+		return myPrivateEntities;
+
+	}
+
+	private Class<? extends AbstractEditTab> getTabClass(ACrisObject co) {
+		if (co instanceof Project) {
+			return EditTabProject.class;
+		} else if (co instanceof OrganizationUnit) {
+			return EditTabOrganizationUnit.class;
+		} else if (co instanceof ResearcherPage) {
+			return EditTabResearcherPage.class;
+		} else {
+			return EditTabDynamicObject.class;
+		}
+	}
+
+}

--- a/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/ProjectDetailsController.java
+++ b/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/ProjectDetailsController.java
@@ -104,7 +104,7 @@ public class ProjectDetailsController
         boolean isAdmin = CrisAuthorizeManager.isAdmin(context,grant);
         boolean canEdit = isAdmin || CrisAuthorizeManager.canEdit(context, applicationService, EditTabProject.class, grant);
         if ((grant.getStatus() == null || grant.getStatus().booleanValue() == false)
-                && !isAdmin)
+                && !canEdit)
         {
             
             if (currUser != null

--- a/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/ResearcherPageDetailsController.java
+++ b/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/ResearcherPageDetailsController.java
@@ -184,7 +184,7 @@ public class ResearcherPageDetailsController
 		boolean canEdit = isAdmin
 				|| CrisAuthorizeManager.canEdit(context, applicationService, EditTabResearcherPage.class, researcher);
         
-        if (isAdmin
+        if (canEdit
                 || (currUser != null && (researcher.getEpersonID() != null && currUser
                         .getID() == researcher.getEpersonID())))
         {

--- a/dspace-cris/jspui-webapp/src/main/webapp/WEB-INF/springmvc-rp-servlet.xml
+++ b/dspace-cris/jspui-webapp/src/main/webapp/WEB-INF/springmvc-rp-servlet.xml
@@ -362,7 +362,14 @@
 			<value>explore</value>
 		</property>		
 	</bean>
-	
+
+	<!-- Private Entities configuration -->
+	<bean id="privateEntitiesController"
+		class="org.dspace.app.webui.cris.controller.PrivateEntitiesController">
+		<property name="detailsView">
+			<value>privateEntities</value>
+		</property>
+	</bean>
 	
 	<!-- Start Researcher controller configurations -->
 	<bean id="detailsResearcherController"
@@ -7007,6 +7014,9 @@
 				<prop key="/stats/*.html">doStatisticsController</prop>
 				<!-- explore -->
 				<prop key="/explore/*">exploreController</prop>
+
+				<!-- Private Entities -->
+				<prop	key="/rp/privateEntities">privateEntitiesController</prop>
 				
 				<!-- Search -->
 				<prop key="/rp/search.htm">searchRPFormController</prop>

--- a/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/privateEntities.jsp
+++ b/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/privateEntities.jsp
@@ -1,0 +1,43 @@
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+<%@ taglib prefix="fmt" uri = "http://java.sun.com/jsp/jstl/fmt" %>
+
+<%@ page import="java.util.List" %>
+<%@ page import="org.dspace.app.cris.model.ACrisObject"%>
+<%@ page import="org.dspace.app.webui.util.UIUtil" %>
+<%@ page import="org.dspace.core.Context" %>
+<%@ page import="org.dspace.core.I18nUtil" %>
+<%@ page import="org.dspace.content.DCDate" %>
+
+<%
+    Context context = UIUtil.obtainContext(request);
+    List<ACrisObject> privateEntities = (List<ACrisObject>) request.getAttribute("privateEntities");
+%>
+
+<div id="private-entities-table">
+	<table id="peTable" class="table table-striped table-bordered table-condensed dataTable no-footer" align="center" summary="Table listing private projects">
+		<thead>
+			<tr>
+				<th id="pe01" style="width: 185px;" aria-controls="wfTable" aria-sort="ascending"><fmt:message key="jsp.mydspace.cris.privateentities.type"/></th>
+				<th id="pe02" aria-controls="peTable"><fmt:message key="jsp.mydspace.cris.privateentities.name"/></th>
+				<th id="pe03" style="width: 185px;" aria-controls="wfTable"><fmt:message key="jsp.mydspace.cris.privateentities.lastmodified"/></th>
+			</tr>
+		</thead>
+		<tbody id="private-entities-table-body">
+		<%
+			for(ACrisObject entity : privateEntities) {
+				String type = I18nUtil.getMessage("jsp.search.results.cris." + entity.getTypeText(), context);
+				String name = entity.getName();
+				String crisID = entity.getCrisID();
+				String lastModified = UIUtil.displayDate(new DCDate(entity.getTimeStampInfo().getLastModificationTime()), true, true, request);
+		%>
+				<tr>
+					<td headers="pe01"><%= type %></td>
+					<td headers="pe02"><a href="<%= request.getContextPath() %>/cris/<%= entity.getPublicPath() %>/<%= crisID %>"><%= name %></a></td>
+					<td headers="pe03"><%= lastModified %></td>
+				</tr>
+		<%
+			}
+		%>
+		</tbody>
+	</table>
+</div>

--- a/dspace-jspui/src/main/webapp/mydspace/main.jsp
+++ b/dspace-jspui/src/main/webapp/mydspace/main.jsp
@@ -97,6 +97,28 @@
 <c:set var="dspace.layout.head.last" scope="request">
     <script type="text/javascript">
     <!--
+
+       /* Function to fetch private CRIS entities for the current user */
+       var fetchPrivateEntities = function() {
+           j.ajax({
+               url : "<%= request.getContextPath() %>/cris/rp/privateEntities",
+               contentType: "text/html; charset=utf-8",
+               beforeSend: function() {
+                   j('#update-private-entities-indicator').show();
+               },
+               success: function(data) {
+                   j('#update-private-entities-indicator').hide();
+                   j('#private-entities-table').html(data);
+                   j('#peTable').DataTable({
+                       "ordering": true
+                           });
+               },
+               error: function(err) {
+                   j('#update-private-entities-indicator').hide();
+                   j('#private-entities-table').html("<span class=\"badge badge-danger\">There was a problem fetching your private entities. Please contact your administrator.</span>");
+               }
+           });
+       };
        var j = jQuery.noConflict();
        var myrpstatus = new Object();
        j(document).ready(function(){
@@ -181,6 +203,7 @@
                };
 
                myRP('status');
+               fetchPrivateEntities();
        });
     -->
     </script>
@@ -608,6 +631,15 @@
 <%
   }
 %>
+
+<!-- Private CRIS entities of the current user; will be populated through fetchPrivateEntities() -->
+<div id="private-entities">
+	<h3>
+		<fmt:message key="jsp.mydspace.cris.privateentities"/>
+		<div id="update-private-entities-indicator" class="loader"></div>
+	</h3>
+	<div id="private-entities-table"></div>
+</div>
 
 	<%if(exportsAvailable!=null && exportsAvailable.size()>0){ %>
 	<h3><fmt:message key="jsp.mydspace.main.heading7"/></h3>

--- a/dspace/config/modules/cris.cfg
+++ b/dspace/config/modules/cris.cfg
@@ -185,3 +185,10 @@ events.feed.field = dc.relation.conference_authority
 
 zdb.search.url = ${cris.zdb.search.url} 
 zdb.detail.url = ${cris.zdb.detail.url}
+
+### Private/Undiscoverable Entities
+# Configure entities, which should be explicitly displayed in 'My DSpace' of the current
+# user despite they're private/discoverable=false.
+# Comma separated list of entities to display (<entity_class_path>:<entity_typeID>)
+rp.privateentities = org.dspace.app.cris.model.Project:10
+


### PR DESCRIPTION
# Rationale

The University of Bamberg requires CRIS entities to be created and edited by users other than administrators. Therefore, an earlier implementation enhanced the policy capabilities of DSpace-CRIS to add single users and/or groups to CRIS entities they don't own to allow modifications by the respective user.

Unfortunately, private CRIS entities are not discoverable through DSpace-CRIS search capabilities so unprivileged users have to deal with writing down URLs to directly access the entity. Even the administrator will have a hard time searching though a potential high number of private CRIS entities in `/cris/administrator/<entity>/list.htm`.

# Table of private CRIS entities in `/mydspace`
This PR addresses this issue by implementing a table of private entities that are currently owned by the current user or the user has sufficient rights to modify them.

![2019-05-20_11-06](https://user-images.githubusercontent.com/24757415/58013011-03742e80-7af6-11e9-930c-b0f9aff8cfbe.png)

The image shows `/mydspace` of a researcher and three CRIS entities. *Dummy project (group)* is shared using group policies, *Dummy project* is a private project of the current researcher, and `Dummy award` is an award created by the administrator and shared with the current researcher.

The configuration is done in `cris.cfg` by adding a comma separated list of `<class>:<id>` to `rp.privateentities`, where `<class>` is the respective Java class, which implements the entity, and `<id>` is the internal id (ex. `rp.privateentities = org.dspace.app.cris.model.Project:10,org.dspace.app.cris.model.ResearchObject:1004`).

Moreover, this PR fixes an issue in the `*DetailsController.java` classes, where the result of the policy evaluation was not used at all. **Edit:** I've created a separate PR which addresses this issue, see https://github.com/4Science/DSpace/pull/82, since it's an issue and this PR is a new feature.

**Edit:** Currently, if there are no private entities, an empty table is displayed. This will be fixed soon, that no table will be shown at all. 