### PR TITLE
Fix flawed 'right to edit' evaluation in *DetailsController.java

### DIFF
--- a/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/DynamicObjectDetailsController.java
+++ b/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/DynamicObjectDetailsController.java
@@ -113,7 +113,7 @@ public class DynamicObjectDetailsController
         boolean isAdmin = CrisAuthorizeManager.isAdmin(context,dyn);
         boolean canEdit = isAdmin || CrisAuthorizeManager.canEdit(context, applicationService, EditTabDynamicObject.class, dyn);
         if ((dyn.getStatus() == null || dyn.getStatus().booleanValue() == false)
-                && !isAdmin)
+                && !canEdit)
         {
             
             if (currUser != null

--- a/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/OUDetailsController.java
+++ b/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/OUDetailsController.java
@@ -108,7 +108,7 @@ public class OUDetailsController
         boolean isAdmin = CrisAuthorizeManager.isAdmin(context,ou);
         boolean canEdit = isAdmin || CrisAuthorizeManager.canEdit(context, applicationService, EditTabOrganizationUnit.class, ou);
         if ((ou.getStatus() == null || ou.getStatus().booleanValue() == false)
-                && !isAdmin)
+                && !canEdit)
         {
             
             if (currUser != null

--- a/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/ProjectDetailsController.java
+++ b/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/ProjectDetailsController.java
@@ -104,7 +104,7 @@ public class ProjectDetailsController
         boolean isAdmin = CrisAuthorizeManager.isAdmin(context,grant);
         boolean canEdit = isAdmin || CrisAuthorizeManager.canEdit(context, applicationService, EditTabProject.class, grant);
         if ((grant.getStatus() == null || grant.getStatus().booleanValue() == false)
-                && !isAdmin)
+                && !canEdit)
         {
             
             if (currUser != null

--- a/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/ResearcherPageDetailsController.java
+++ b/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/ResearcherPageDetailsController.java
@@ -184,7 +184,7 @@ public class ResearcherPageDetailsController
 		boolean canEdit = isAdmin
 				|| CrisAuthorizeManager.canEdit(context, applicationService, EditTabResearcherPage.class, researcher);
         
-        if (isAdmin
+        if (canEdit
                 || (currUser != null && (researcher.getEpersonID() != null && currUser
                         .getID() == researcher.getEpersonID())))
         {


### PR DESCRIPTION
# Rationale
Whenever an user accesses a *private* CRIS entity he/she has sufficient rights to modify and this user is not the original creator of the entity, it renders an 'Authorization Required' error.
This is because the original check `(dyn.getStatus() == null || dyn.getStatus().booleanValue() == false) && !isAdmin)` evaluates only against whether the current user is an administrator or not for private entities and does not take into account if the current users has sufficient rights to edit the entity.

Therefore the `!isAdmin/isAdmin` checks in the controllers must be `!canEdit/canEdit` to make this work properly.