### PR TITLE
Fix rendering of multiline text widgets for CRIS entities

### DIFF
--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -2058,6 +2058,9 @@ help.jdyna.message.tab.priority = Priority of tab shown in relation to other Tab
 help.jdyna.message.tab.title = Label displayed on the tab
 help.jdyna.message.tab.shortname = A unique name for this tab
 
+help.jdyna.message.rendering.text.toolbar = Select HTML toolbar
+jsp.layout.hku.label.propertiesdefinition.rendering.text.toolbar = Toolbar
+
 jsp.dspace-admin.hku.jdyna-configuration.newdynamicfield = Create a new field
 jsp.layout.hku.label.containableslist = Fields available
 

--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/batch/ImportCRISDataModelConfiguration.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/batch/ImportCRISDataModelConfiguration.java
@@ -1149,6 +1149,16 @@ public class ImportCRISDataModelConfiguration
             s.setCol(cols);
             s.setRow(rows);
             builderW.addPropertyValue("dimensione", s);
+            /*
+             * Temporary fix to properly render line breaks as long as
+             * JDynA's richt text editors are not available in DSpace CRIS.
+             * 'htmlToolbar' is explicitely set to 'nessuna' otherwise it
+             * would be 'null' which prevents proper rendering of text.
+             * See 4science/JDynA, commit: 4b16d36095fa85ed86569241f01d3450ed605f9d
+             * jdyna-web/jdyna-web-webapp/jdyna-webmvc/jdyna-webmvc-api/target/classes/
+             * META-INF/tags/display.tag, line 394
+             */
+            builderW.addPropertyValue("htmlToolbar", "nessuna");
         }
         else if (widget.equals("boolean"))
         {

--- a/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/tabs/propertiesDefinitionForm.jsp
+++ b/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/tabs/propertiesDefinitionForm.jsp
@@ -309,6 +309,11 @@
 					&nbsp;
 					<dyna:boolean propertyPath="real.rendering.multilinea"
 								labelKey="jsp.layout.hku.label.propertiesdefinition.rendering.text.multiline" helpKey="help.jdyna.message.rendering.text.multiline"/>
+                    <spring:bind path="real.rendering.htmlToolbar">
+                            <dyna:label propertyPath="real.rendering.htmlToolbar" labelKey="jsp.layout.hku.label.propertiesdefinition.rendering.text.toolbar" helpKey="help.jdyna.message.rendering.text.toolbar"/>
+                            <div class="dynaClear"></div>
+                            <input checked="checked" id="real.rendering.htmlToolbar" name="real.rendering.htmlToolbar" type="radio" value="nessuna"> None</input>
+                    </spring:bind>
 					<dyna:text visibility="false" propertyPath="real.rendering.dimensione.row"
 								labelKey="jsp.layout.hku.label.propertiesdefinition.rendering.text.row" helpKey="help.jdyna.message.rendering.text.row"/>
 					<div class="dynaClear">


### PR DESCRIPTION
## Rationale
Recent changes now allow the use of multiline text widgets (`textarea`) in CRIS entities and therefore allow user input containing line breaks. Unfortunately, there's an property (`htmlToolbar`) associated with JDynA's text widget, which is used to decide whether the widget implements an rich text editor or not. But this feature is not used in DSpace CRIS, since it doesn't implement such editors, hence, `htmlToolbar` is always `null` in DSpace CRIS.

Because JDynA expects `htmlToolbar` to be explicitly set to `nessuna` if no rich text editor is used, JDynA does not apply its `nl2br` method to replace line breaks with `<br/>` to the content, which results in the content being rendered in one line instead of respecting line breaks.

## Set `htmlToolbar` to `nessuna` by default
This PR fixes this problem by setting `htmlToolbar` to `nessuna` on cris-configuration import by default.
For multiline text widgets created through the front-end there's a new option ('Toolbar') exposed, which is set to the fixed value *'None'* (`nessuna`).

## JDynA
This might be a issue with JDynA and not DSpace CRIS so accepting https://github.com/4Science/JDynA/pull/2 might be a more appropriate solution.