### PR TITLE
Fix query filter value for browse results

### DIFF
--- a/dspace-api/src/main/java/org/dspace/browse/BrowseDAOOracle.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseDAOOracle.java
@@ -411,10 +411,10 @@ public class BrowseDAOOracle implements BrowseDAO
                 String authorityResult = row.getStringColumn("authority");
                 if (enableBrowseFrequencies){
                     long frequency = row.getLongColumn("num");
-                    results.add(new String[]{valueResult,authorityResult, String.valueOf(frequency)});
+                    results.add(new String[]{valueResult, "", authorityResult, String.valueOf(frequency)});
                 }
                 else
-                    results.add(new String[]{valueResult,authorityResult, ""});
+                    results.add(new String[]{valueResult, "", authorityResult, ""});
             }
 
             return results;

--- a/dspace-api/src/main/java/org/dspace/browse/BrowseDAOPostgres.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseDAOPostgres.java
@@ -416,10 +416,10 @@ public class BrowseDAOPostgres implements BrowseDAO
                 String authorityResult = row.getStringColumn("authority");
                 if (enableBrowseFrequencies){
                     long frequency = row.getLongColumn("num");
-                    results.add(new String[]{valueResult,authorityResult, String.valueOf(frequency)});
+                    results.add(new String[]{valueResult, "", authorityResult, String.valueOf(frequency)});
                 }
                 else
-                    results.add(new String[]{valueResult,authorityResult, ""});
+                    results.add(new String[]{valueResult, "", authorityResult,  ""});
             }
 
             return results;

--- a/dspace-api/src/main/java/org/dspace/browse/BrowseInfo.java
+++ b/dspace-api/src/main/java/org/dspace/browse/BrowseInfo.java
@@ -486,13 +486,13 @@ public class BrowseInfo
 
     /**
      * Return the results of the Browse as an array of String array.
-     * The first element (i.e. index 0) is the value, the second is the authority key
+     * The first element (i.e. index 0) is the value, the second is the query value and the third is the authority key
      *
      * @return The results of the Browse as a String array.
      */
     public String[][] getStringResults()
     {
-        return (String[][]) results.toArray(new String[results.size()][2]);
+        return (String[][]) results.toArray(new String[results.size()][3]);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
+++ b/dspace-api/src/main/java/org/dspace/browse/SolrBrowseDAO.java
@@ -283,7 +283,7 @@ public class SolrBrowseDAO implements BrowseDAO
                 FacetResult c = facet.get(i);
                 String freq = showFrequencies ? String.valueOf(c.getCount())
                         : "";
-                result.add(new String[] { c.getDisplayedValue(),
+                result.add(new String[] { c.getDisplayedValue(), c.getAsFilterQuery(),
                         c.getAuthorityKey(), freq });
             }
         }
@@ -295,7 +295,7 @@ public class SolrBrowseDAO implements BrowseDAO
                 FacetResult c = facet.get(i);
                 String freq = showFrequencies ? String.valueOf(c.getCount())
                         : "";
-                result.add(new String[] { c.getDisplayedValue(),
+                result.add(new String[] { c.getDisplayedValue(), c.getAsFilterQuery(),
                         c.getAuthorityKey(), freq });
             }
         }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -2130,7 +2130,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 		String displayedValue = transformDisplayedValue(context, facetField.getName(), facetValue.getName());
 		String authorityValue = transformAuthorityValue(context, facetField.getName(), facetValue.getName());
 		String sortValue = transformSortValue(context, facetField.getName(), facetValue.getName());
-		String filterValue = displayedValue;
+		String filterValue = transformFilterValue(context, facetField.getName(), facetValue.getName());
 		if (StringUtils.isNotBlank(authorityValue))
 		{
 		    filterValue = authorityValue;
@@ -2454,6 +2454,45 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             {
                 String[] split = fqParts[i].split(AUTHORITY_SEPARATOR, 2);
                 valueBuffer.append(split[0]);
+            }
+            value = valueBuffer.toString();
+        }else if(value.matches("\\((.*?)\\)"))
+        {
+            //The brackets where added for better solr results, remove the first & last one
+            value = value.substring(1, value.length() -1);
+        }
+        return value;
+    }
+
+    protected String transformFilterValue(Context context, String field,
+            String value) throws SQLException
+    {
+        if (value == null)
+        {
+            return null;
+        }
+        if(field.equals("location.comm") || field.equals("location.coll"))
+        {
+            value = locationToName(context, field, value);
+        }
+        else if (field.endsWith("_filter") || field.endsWith("_ac")
+          || field.endsWith("_acid"))
+        {
+            //We have a filter make sure we split !
+            String separator = new DSpace().getConfigurationService().getProperty("discovery.solr.facets.split.char");
+            if(separator == null)
+            {
+                separator = FILTER_SEPARATOR;
+            }
+            //Escape any regex chars
+            separator = java.util.regex.Pattern.quote(separator);
+            String[] fqParts = value.split(separator);
+            StringBuffer valueBuffer = new StringBuffer();
+            int start = fqParts.length / 2;
+            for(int i = start; i < fqParts.length; i++)
+            {
+                String[] fqPartsParts = fqParts[i].split(AUTHORITY_SEPARATOR, 2);
+                valueBuffer.append(fqPartsParts[0]);
             }
             value = valueBuffer.toString();
         }else if(value.matches("\\((.*?)\\)"))

--- a/dspace-jspui/src/main/webapp/browse/single.jsp
+++ b/dspace-jspui/src/main/webapp/browse/single.jsp
@@ -281,7 +281,7 @@
     {
 %>
                 <li class="list-group-item">
-                    <a href="<%= sharedLink %><% if (results[i][1] != null) { %>&amp;authority=<%= URLEncoder.encode(results[i][1], "UTF-8") %>" class="authority <%= bix.getName() %>"><%= Utils.addEntities(results[i][0]) %></a> <% } else { %>&amp;value=<%= URLEncoder.encode(results[i][0], "UTF-8") %>"><%= Utils.addEntities(results[i][0]) %></a> <% } %>
+                    <a href="<%= sharedLink %><% if (results[i][2] != null) { %>&amp;authority=<%= URLEncoder.encode(results[i][2], "UTF-8") %>" class="authority <%= bix.getName() %>"><%= Utils.addEntities(results[i][0]) %></a> <% } else { %>&amp;value=<%= URLEncoder.encode(results[i][1], "UTF-8") %>"><%= Utils.addEntities(results[i][0]) %></a> <% } %>
 					<%= StringUtils.isNotBlank(results[i][2])?" <span class=\"badge\">"+results[i][2]+"</span>":""%>
                 </li>
 <%

--- a/dspace-jspui/src/main/webapp/browse/static-tagcloud-browse.jsp
+++ b/dspace-jspui/src/main/webapp/browse/static-tagcloud-browse.jsp
@@ -42,7 +42,7 @@
 	    for (int i = 0; i < results2.length; i++)
 	    {
 	    	String value = Utils.addEntities(results2[i][0]);
-	    	int count = Integer.parseInt(results2[i][2]);
+	        int count = Integer.parseInt(results2[i][3]);
 			data.put(value, count);
 	    }
     %>


### PR DESCRIPTION
# Rationale
Currently, the query `filterValue` for browse results is the same a the `displayedValue`.
Since we introduce multilingual browse indexes in https://github.com/4Science/DSpace/pull/89 the use of `displayedValue` as `filterValue` is more than impractical and will break the query.

This PR introduces the `filterValue` as distinct field which is used to build a valid query filter in the font end. The new method `transformFilterValue` is introduced in consideration of https://github.com/4Science/DSpace/pull/89.