### PR TITLE
Fix issue in RPMultiAuthority.java which prevents migration processes to properly find best matching RPs for given name

### DIFF
--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/integration/RPMultiAuthority.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/integration/RPMultiAuthority.java
@@ -303,7 +303,7 @@ public class RPMultiAuthority extends CRISAuthority
                 for (DSpaceObject dso : result.getDspaceObjects())
                 {
                     ResearcherPage rp = (ResearcherPage) dso;
-                    buildAggregateByExtra(rp);
+                    choiceList.addAll(buildAggregateByExtra(rp));
                 }
             }
 


### PR DESCRIPTION
# Rationale

With the latest changes, our migration processes were not able to assign author RPs properly to our publications. The flaw lies in the newly introduced `RPMultiAuthority` we are using.

When using `RPMultiAuthority` as choices plugin, every functionality which relies on `getBestMatches()` to get a list of possible matching RPs, will fail to assign the RPs properly, because the possible matches are ... never returned.

This PR fixes this issue, what seems like a careless mistake.