### PR TITLE
D4CRIS-25 XLS import thrown ArrayIndexOutOfBoundsException

### DIFF
--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/importexport/ExcelBulkChange.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/importexport/ExcelBulkChange.java
@@ -62,7 +62,10 @@ public class ExcelBulkChange implements IBulkChange {
 		int index = -1;
 		if(this.header.contains(field)) {
 			index = this.header.indexOf(field);
-			return new ExcelBulkField(row[index]);
+			if (index < row.length)
+				return new ExcelBulkField(row[index]);
+			else
+				return new ExcelBulkField(new EmptyCell());
 		}
 		return new ExcelBulkField(new EmptyCell());
 	}
@@ -72,7 +75,10 @@ public class ExcelBulkChange implements IBulkChange {
 		int index = -1;
 		if(this.header.contains(field)) {
 			index = this.header.indexOf(field);
-			return new ExcelBulkFieldLink(row[index]);
+			if (index < row.length)
+			 	return new ExcelBulkFieldLink(row[index]);
+			else
+				return new ExcelBulkFieldLink(new EmptyCell());
 		}		
 		return new ExcelBulkFieldLink(new EmptyCell());
 	}
@@ -84,7 +90,10 @@ public class ExcelBulkChange implements IBulkChange {
         if (this.header.contains(field))
         {
             index = this.header.indexOf(field);
-            return new ExcelBulkFieldPointer(row[index]);
+            if (index < row.length)
+            	return new ExcelBulkFieldPointer(row[index]);
+            else
+				return new ExcelBulkFieldPointer(new EmptyCell());
         }        
         return new ExcelBulkFieldPointer(new EmptyCell());
     }


### PR DESCRIPTION
Fix issue #14 
> The workaround is to insert a control char (e.g. #) in the last empties columns to control the empty cell in the row (this works as delimiter char).

The correction described is no longer necessary but the code continues to work even with files with the control character (#).