### PR TITLE
Fix bug where tab's query arg 'onlytab=true' is applied to pagination links in box

### DIFF
--- a/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/jdyna/custom/dspaceitems.jsp
+++ b/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/jdyna/custom/dspaceitems.jsp
@@ -75,7 +75,7 @@
 	    }
 	}
 	
-	String query = request.getQueryString();
+	String query = request.getQueryString().replaceAll("[?&]?onlytab=true", "");
 	boolean globalShowFacets = false;
 	if (info!=null && info.getItems()!=null && info.getItems().length > 0) {
 	    


### PR DESCRIPTION
There's a minor bug, where the query arg (`onlytab=true`) is applied to the pagination links of DSpace items in the box and render the page unusable when clicked.