### PR TITLE
4CRIS-810 Script to unsubscribe an eperson from all the notification

### DIFF
--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/batch/ScriptCrisUnsubscribeEPerson.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/batch/ScriptCrisUnsubscribeEPerson.java
@@ -3,7 +3,7 @@
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
  *
- * https://github.com/CILEA/dspace-cris/wiki/License
+ * http://www.dspace.org/license/
  */
 package org.dspace.app.cris.batch;
 
@@ -32,18 +32,21 @@ public class ScriptCrisUnsubscribeEPerson {
 			String[] args) throws ParseException, SQLException {
 		log.info("#### START UNSUBSCRIBE EPERSON: -----" + new Date() + " ----- ####");
 		Context dspaceContext = new Context();
-		dspaceContext.setIgnoreAuthorization(true);
+		dspaceContext.turnOffAuthorisationSystem();
+		dspaceContext.turnOffItemWrapper();
 		CommandLineParser parser = new PosixParser();
 
 		Options options = new Options();
 		options.addOption("h", "help", false, "help");
 		options.addOption("e", "email", true, "Email of ePerson *");
+		options.addOption("q", "quiet", false, "Skip sending the summary email");
 		
 		CommandLine line = parser.parse(options, args);
 		String eperson = "";
 		if (line.hasOption("e")) {
 			eperson = line.getOptionValue("e");
 		}
+		boolean skipEmail = line.hasOption('q');
 
 		if (line.hasOption('h') || StringUtils.isEmpty(eperson)) {
 			HelpFormatter myhelp = new HelpFormatter();
@@ -57,12 +60,15 @@ public class ScriptCrisUnsubscribeEPerson {
 		}
 
 		try {
-			UnsubscribeEPersionUtils.process(dspaceContext, eperson);
+			UnsubscribeEPersionUtils.process(dspaceContext, eperson, skipEmail);
 		} catch (Exception e) {
 			log.error(e.getMessage());
 		}
 		
 		log.info("#### END UNSUBSCRIBE EPERSON: -----" + new Date() + " ----- ####");
+		// Finish off and tidy up
+		dspaceContext.restoreAuthSystemState();
+        dspaceContext.restoreItemWrapperState();
 		dspaceContext.complete();
 	}
 }

--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/batch/ScriptCrisUnsubscribeEPerson.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/batch/ScriptCrisUnsubscribeEPerson.java
@@ -1,0 +1,68 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/CILEA/dspace-cris/wiki/License
+ */
+package org.dspace.app.cris.batch;
+
+import java.sql.SQLException;
+import java.util.Date;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.PosixParser;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
+import org.dspace.app.cris.util.UnsubscribeEPersionUtils;
+import org.dspace.core.Context;
+
+public class ScriptCrisUnsubscribeEPerson {
+	/** log4j logger */
+	private static Logger log = Logger.getLogger(ScriptCrisUnsubscribeEPerson.class);
+
+	/**
+	 * Batch script to disable notification. See the technical documentation for further details. 
+	 */
+	public static void main(
+			String[] args) throws ParseException, SQLException {
+		log.info("#### START UNSUBSCRIBE EPERSON: -----" + new Date() + " ----- ####");
+		Context dspaceContext = new Context();
+		dspaceContext.setIgnoreAuthorization(true);
+		CommandLineParser parser = new PosixParser();
+
+		Options options = new Options();
+		options.addOption("h", "help", false, "help");
+		options.addOption("e", "email", true, "Email of ePerson *");
+		
+		CommandLine line = parser.parse(options, args);
+		String eperson = "";
+		if (line.hasOption("e")) {
+			eperson = line.getOptionValue("e");
+		}
+
+		if (line.hasOption('h') || StringUtils.isEmpty(eperson)) {
+			HelpFormatter myhelp = new HelpFormatter();
+			myhelp.printHelp("ScriptCrisBulkChanges \n", options);
+			System.out
+					.println("\n\nUSAGE:\n ScriptCrisBulkChanges -e email -\n");
+			System.out
+					.println("* Please note: -e is mandatory and is the email of an ePerson");
+			
+			System.exit(0);
+		}
+
+		try {
+			UnsubscribeEPersionUtils.process(dspaceContext, eperson);
+		} catch (Exception e) {
+			log.error(e.getMessage());
+		}
+		
+		log.info("#### END UNSUBSCRIBE EPERSON: -----" + new Date() + " ----- ####");
+		dspaceContext.complete();
+	}
+}

--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/util/UnsubscribeEPersionUtils.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/util/UnsubscribeEPersionUtils.java
@@ -1,0 +1,162 @@
+package org.dspace.app.cris.util;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.dspace.app.cris.model.ACrisObject;
+import org.dspace.app.cris.service.ApplicationService;
+import org.dspace.app.cris.service.CrisSubscribeService;
+import org.dspace.app.cris.statistics.StatSubscriptionViewBean;
+import org.dspace.app.cris.statistics.service.StatSubscribeService;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.core.Email;
+import org.dspace.core.I18nUtil;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Subscribe;
+import org.dspace.utils.DSpace;
+
+public class UnsubscribeEPersionUtils {
+	/** log4j logger */
+	private static Logger log = Logger.getLogger(UnsubscribeEPersionUtils.class);
+	
+	/**
+	 * Unsubscribe an eperson from all the notification.
+	 * 
+	 * @param context The context
+	 * @param email The mail related to an ePerson
+	 * @throws Exception
+	 */
+	public static void process(
+			Context context, String email) throws Exception {
+				
+		EPerson eperson = EPerson.findByEmail(context, email);
+		if (eperson == null) {
+			throw new Exception("The email " + email + " is not related to any ePerson.");
+		}
+		
+		log.debug("Using email template: unsubscriptions");
+		Email recoverEmail = Email.getEmail(I18nUtil.getEmailFilename(Locale.getDefault(), "unsubscriptions"));
+		String recipient = ConfigurationManager.getProperty("alert.recipient");
+		String notify = ConfigurationManager.getProperty("registration.notify");
+		if (StringUtils.isNotBlank(recipient)) {
+			log.debug("Using alert.recipient: " + recipient);
+
+			recoverEmail.addRecipient(recipient);
+		}
+		else if (StringUtils.isNotBlank(notify)) {
+			log.debug("Using registration.notify: " + recipient);
+			
+			recoverEmail.addRecipient(notify);
+		}
+		else {
+			throw new Exception("No administration email configurated. Fix configuration value alert.recipient or registration.notify.");
+		}
+		log.debug("{0}: " + email);
+		recoverEmail.addArgument(email);			// {0}
+
+		StringBuilder list = new StringBuilder();
+		// get subscription to community
+		Community[] communities = Subscribe.getCommunitySubscriptions(context, eperson);
+		if (communities != null && communities.length > 0) {
+			for (Community c : communities) {
+				list.append("\t" + c.getName() + ", with handle " + c.getHandle() + "\n");
+				
+				Subscribe.unsubscribe(context, eperson, Community.find(context, c.getID()));
+			}
+		}
+		log.debug("unsubscribe communities: {1}: " + list.toString());
+		recoverEmail.addArgument(list.toString());	// {1}
+		
+		list.setLength(0);
+		// get subscription to collection
+		Collection[] collections = Subscribe.getSubscriptions(context, eperson);
+		if (collections != null && collections.length > 0) {
+			for (Collection c : collections) {
+				list.append("\t" + c.getName() + ", handle " + c.getHandle() + "\n");
+				
+				Subscribe.unsubscribe(context, eperson, Collection.find(context, c.getID()));
+			}
+		}
+		log.debug("unsubscribe collections: {2}: " + list.toString());
+		recoverEmail.addArgument(list.toString());	// {2}
+		
+		list.setLength(0);
+		// get cris object subscriptions
+		DSpace dspace = new DSpace();
+		ApplicationService applicationService = dspace.getServiceManager().getServiceByName("applicationService",
+				ApplicationService.class);
+		CrisSubscribeService crisUnsubscribeService = new CrisSubscribeService(applicationService);
+		List<String> crisObjUuids = crisUnsubscribeService.getSubscriptions(eperson);
+		if (crisObjUuids != null && crisObjUuids.size() > 0) {
+			for (String uuid : crisObjUuids) {
+				ACrisObject o = applicationService.getEntityByUUID(uuid);
+				list.append("\t" + o.getName() + ", handle " + o.getHandle() + ", id " + o.getCrisID() + "\n");
+				
+				crisUnsubscribeService.unsubscribe(eperson, uuid);
+			}
+		}
+		log.debug("unsubscribe cris Objects: {3}: " + list.toString());
+		recoverEmail.addArgument(list.toString());	// {3}
+		
+		list.setLength(0);
+		// get statistical subscriptioons
+		StatSubscribeService statUnsibscribeService = new StatSubscribeService(applicationService);
+		List<StatSubscriptionViewBean> statSubViewBeans = statUnsibscribeService.getSubscriptions(context, eperson);
+		if (statSubViewBeans != null && statSubViewBeans.size() > 0) {
+			for (StatSubscriptionViewBean s : statSubViewBeans) {
+				StringBuilder freq = new StringBuilder();
+				int len = 0;
+				for (Integer f : s.getFreqs()) {
+					String fasS = Integer.toString(f);
+					
+					freq.ensureCapacity(len + fasS.length() + 2);
+					if (len > 0)
+						freq.append(" ,");
+					freq.append(fasS);
+					len += fasS.length() + 2;
+				}
+				
+				String label = "";
+				String type = "";
+				switch (s.getType()) {
+					case Constants.ITEM:
+						label = "handle";
+						type = "type item";
+						break;
+						
+					case Constants.COLLECTION:
+						label = "handle";
+						type = "type colllection";
+						break;
+						
+					case Constants.COMMUNITY:
+						label = "handle";
+						type = "type community";
+						break;
+						
+					default:
+						label = "uuid";
+						
+						ACrisObject criso = applicationService.getEntityByUUID(s.getId());
+						type = "handle " + criso.getHandle() + ", id " + criso.getCrisID();
+						break;
+				}
+				list.append("\t" + s.getObjectName() + ", frequences (" + freq 
+						+ "), " + label + " " + s.getId() 
+						+ ", " + type + "(" + s.getType() + ")\n");
+
+				statUnsibscribeService.unsubscribeUUID(eperson, s.getId());
+			}
+		}
+		log.debug("unsubscribe statistics: {4}: " + list.toString());
+		recoverEmail.addArgument(list.toString());	// {4}
+		
+		recoverEmail.send();
+	}
+}

--- a/dspace/config/emails/unsubscriptions
+++ b/dspace/config/emails/unsubscriptions
@@ -1,0 +1,24 @@
+# E-mail sent to designated address when unsubscribe eperson command was requested
+#
+# Parameters: {0} EPerson email
+#             {1} list of communities
+#             {2} list of collections
+#             {3} list of CRIS items
+#             {4} list of statistics
+#
+# See org.dspace.core.Email for information on the format of this file.
+#
+Subject: Unsubscribed eperson {0} from the following communities, collections, Cris items, statistics
+The following email was sent since an unsubscribe eperson command, related to {0}, was requested.
+
+The ePerson was unsubscribed from the following communities:
+{1}
+
+The ePerson was unsubscribed from the following collections:
+{2}
+
+The ePerson was unsubscribed from the following CRIS items:
+{3}
+
+The ePerson was unsubscribed from the following statistics:
+{4}


### PR DESCRIPTION
A new script was created to unsubscribe an ePerson from all notifications: all communities, collections, Cris objects and statistics. After execution, the command sent an email to the alert.recipient or registration.notify email address.

The command is executed using the email as parameter:
`dspace dsrun org.dspace.app.cris.batch.ScriptCrisUnsubscribeEPerson -e email`
