### PR TITLE
Fix bug where, on import, private metadata fields are set to public despite no visibility value is given

### DIFF
--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/util/ImportExportUtils.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/util/ImportExportUtils.java
@@ -166,7 +166,9 @@ public class ImportExportUtils {
 	 * Defaul visibility, it is used when no visibility attribute and old value
 	 * founded
 	 */
-	public static final String DEFAULT_VISIBILITY = "1";
+	public static final String DEFAULT_VISIBILITY = "PUBLIC";
+	public static final String PUBLIC_VISIBILITY = "PUBLIC";
+	public static final String HIDE_VISIBILITY = "HIDE";
 
 	public static final String LABELCAPTION_VISIBILITY_SUFFIX = " visibility";
 
@@ -1837,7 +1839,7 @@ public class ImportExportUtils {
 		for (ValoreDTO temp : old) {
 			pe.setValue(temp.getObject());
 			if (pe.getAsText().equals(nodetext)) {
-				vis = temp.getVisibility() ? "1" : "0";
+				vis = temp.getVisibility() ? PUBLIC_VISIBILITY : HIDE_VISIBILITY;
 				founded = true;
 				break;
 			}


### PR DESCRIPTION
There's currently a bug, which sets metadata fields to public if no visibility value is provided on import, because the current visibility value is processed incorrectly.

On import, when a new visibility value (ie. `PUBLIC`/`HIDE`) is provided, `VisibilityConstants.getIDFromDescription()` returns the correct `int` value.

https://github.com/4Science/DSpace/blob/1bf02011863c528ca7deff12cd88549768c9f321/dspace-cris/api/src/main/java/org/dspace/app/cris/util/ImportExportUtils.java#L1657-L1660

However, if no visibility value is given, `checkOldVisibility()` jumps in and returns the current visibliity.

https://github.com/4Science/DSpace/blob/1bf02011863c528ca7deff12cd88549768c9f321/dspace-cris/api/src/main/java/org/dspace/app/cris/util/ImportExportUtils.java#L1652-L1655

Unfortunately, the return value of `checkOldVisibility()` is either `0` or `1` as `String`, which however is incorrectly processed by `VisibilityConstants.getIDFromDescription()`.
`VisibilityConstants.getIDFromDescription()` only accepts `PUBLIC` or `HIDE` and will return the `DEFAULT_VISIBILITY` otherwise, which is `PUBLIC`.

For example, this bug affects our LDAP-Sync, which runs every night and sets metadata fields to public which were intentionally set to private by the user.  