### PR TITLE
Supplementary unicode characters breaking OAI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1416,7 +1416,7 @@
          <dependency>
             <groupId>xalan</groupId>
             <artifactId>xalan</artifactId>
-            <version>2.7.1</version>
+            <version>2.7.0</version>
          </dependency>
          <dependency>
             <groupId>xerces</groupId>


### PR DESCRIPTION
As stated on https://jira.duraspace.org/browse/DS-3733, there is a problem with Xalan 2.7.1 when supplementary Unicode characters   are in the metadata of an item, causing the break of OAI webapp.
The solution is to revert to Xalan 2.7..0