### PR TITLE
adds crossref apikey variable to local.cfg example

### DIFF
--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -229,3 +229,4 @@ submission.lookup.webofknowledge.ip.authentication = false
 submission.lookup.webofknowledge.user =
 submission.lookup.webofknowledge.password =
 
+bte.crossref.apikey =


### PR DESCRIPTION
While installing DSpace CRIS 7 I found a problem with a missing variable in local.cfg.EXAMPLE. I have just added that variable.