### PR TITLE
Implementation of an organization unit tree

### DIFF
--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/util/OrganizationUnitTreeMaker.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/util/OrganizationUnitTreeMaker.java
@@ -1,0 +1,254 @@
+package org.dspace.app.cris.util;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrDocumentList;
+import org.dspace.app.cris.model.CrisConstants;
+import org.dspace.app.cris.model.OrganizationUnit;
+import org.dspace.app.cris.service.ApplicationService;
+import org.dspace.discovery.SearchService;
+import org.dspace.discovery.SearchServiceException;
+import org.dspace.utils.DSpace;
+
+
+public class OrganizationUnitTreeMaker {
+
+    /** log4j logger */
+    private static Logger log = Logger.getLogger(OrganizationUnitTreeMaker.class);
+
+    private static OrganizationUnitTreeMaker instance = null;
+
+    private String ouTreeAsHTML = "";
+    private int ouCounter = 0;
+    
+    private String ouMetrics = " <span class=\"orgunit-shortmetrics\">(<i class=\"fa fa-publications fa-75em\"></i> {{pubCount}} / <i class=\"fa fa-fundings fa-75em\"></i> {{projCount}} / <i class=\"fa fa-researcherprofiles fa-75em\"></i> {{rpCount}})</span>";
+
+    private OrganizationUnitTreeMaker() {
+    }
+
+    public static synchronized OrganizationUnitTreeMaker getInstance() {
+        if (instance == null) {
+            instance = new OrganizationUnitTreeMaker();
+            instance.updateOuTree();
+        }
+        return instance;
+    }
+
+    public String getTreeAsHTML() {
+        return ouTreeAsHTML;
+    }
+
+    public synchronized void updateOuTree() {
+
+        System.out.println("Updating organization unit tree");
+
+        DSpace dspace = new DSpace();
+        ApplicationService applicationService = dspace.getServiceManager().getServiceByName("applicationService",
+                ApplicationService.class);
+        SearchService searchService = dspace.getSingletonService(SearchService.class);
+
+        List<OrganizationUnit> ous = fetchOus(applicationService, searchService);
+        ouTreeAsHTML = (ous.size() > 0) ? createOuTreeAsHTML(searchService, ous)
+                : "<small style=\"font-style: italic;\">Unfortunately we missed to update the organization unit tree. Please contact us.</small>";
+
+        System.out.println("Finished updating organization unit tree");
+
+    }
+
+    private List<OrganizationUnit> fetchOus(ApplicationService applicationService, SearchService searchService) {
+
+        System.out.println("Fetching organization units from Solr");
+        List<OrganizationUnit> ous = new LinkedList<>();
+
+        SolrQuery query = new SolrQuery("{!field f=search.resourcetype}" + CrisConstants.OU_TYPE_ID);
+        query.setRows(Integer.MAX_VALUE);
+
+        try {
+            QueryResponse response = searchService.search(query);
+            SolrDocumentList docList = response.getResults();
+            Iterator<SolrDocument> solrDoc = docList.iterator();
+            while (solrDoc.hasNext()) {
+                SolrDocument doc = solrDoc.next();
+                Integer ouId = (Integer) doc.getFirstValue("search.resourceid");
+                OrganizationUnit ou = applicationService.get(OrganizationUnit.class, ouId);
+                if(ou != null && ou.getStatus()) ous.add(ou);
+            }
+        } catch (SearchServiceException e) {
+            log.error(e);
+            return new LinkedList<OrganizationUnit>();
+        }
+
+        ous.sort(new Comparator<OrganizationUnit>() {
+            @Override
+            public int compare(OrganizationUnit o1, OrganizationUnit o2) {
+                try {
+                    return o1.getMetadata("priority").compareTo(o2.getMetadata("priority"));
+                } catch (NullPointerException e) {
+                    System.err.println("Unable to sort: \"" + o1.getName() + "\", \"" + o2.getName() + "\". One has no valid \"priority\" field.");
+                    return 0;
+                }
+            }
+        });
+
+        return ous;
+    }
+
+    private String createOuTreeAsHTML(SearchService searchService, List<OrganizationUnit> ous) {
+
+        System.out.println("Starting to create organisation unit tree as html");
+        StringBuilder builder = new StringBuilder();
+
+        builder.append("<div class=\"panel-group\" id=\"accordion\" role=\"tablist\">");
+
+        ouCounter = 0;
+        for (OrganizationUnit ou : ous) {
+
+            if (ou != null && ou.getName() != null && ou.getMetadata("parentorgunit") == null) {
+                System.out.println("Processing \"" + ou.getName() + "\"...");
+                OrganizationUnitWrapper firstLevelOU = createOuHierarchy(searchService, ou, ous);
+                builder.append(firstLevelOU.asHTML);
+                ouCounter++;
+            }
+        }
+
+        builder.append("</div>");
+        return builder.toString();
+    }
+
+    /*
+     * Creates single organization unit hierarchy for single organization unit.
+     */
+    private OrganizationUnitWrapper createOuHierarchy(SearchService searchService, OrganizationUnit ou, List<OrganizationUnit> ous) {
+
+        System.out.println("  Creating hierarchy for \"" + ou.getName() + "\"...");
+
+        StringBuilder builder = new StringBuilder();
+        OrganizationUnitWrapper currentOU = new OrganizationUnitWrapper();
+
+        List<OrganizationUnit> children = getChildren(ou, ous);
+
+        SolrQuery pubQuery = new SolrQuery("ubg.faculty.org_authority:" + ou.getCrisID());
+        SolrQuery rpQuery = new SolrQuery("crisrp.dept_authority:" + ou.getCrisID());
+        SolrQuery projQuery = new SolrQuery("crisproject.deptproject_authority:" + ou.getCrisID());
+        pubQuery.setRows(Integer.MAX_VALUE);
+        rpQuery.setRows(Integer.MAX_VALUE);
+        projQuery.setRows(Integer.MAX_VALUE);
+        try {
+            currentOU.pubCount = searchService.search(pubQuery).getResults().size();
+            currentOU.rpCount = searchService.search(rpQuery).getResults().size();
+            currentOU.projCount = searchService.search(projQuery).getResults().size();
+        } catch (SearchServiceException e) {
+            log.error(e);
+        }
+        System.out.println("\t\"" + ou.getName() + "\" has " + currentOU.pubCount + " publications, " + currentOU.projCount + " projects, and " + currentOU.rpCount + " researcher");
+
+        if (children.size() > 0) {
+            System.out.println("\t\"" + ou.getName() + "\" has " + children.size()
+                    + " children");
+            builder.append("<div class=\"panel-item\">");
+            builder.append("<div class=\"panel-heading collapsed accordion-toggle\" role=\"tab\" id=\"heading");
+            builder.append("outreemaker" + ouCounter);
+            builder.append("\" data-toggle =\"collapse\" href=\"#collapse");
+            builder.append("outreemaker" + ouCounter);
+            builder.append("\" aria-expanded=\"false\" aria-controls=\"collapse");
+            builder.append("outreemaker" + ouCounter);
+            builder.append("\">");
+            builder.append("<i style=\"color: rgb(0, 69, 124);\" class=\"fas fa-angle-down\"></i>");
+            builder.append("<a href=\"../ou/");
+            builder.append(ou.getCrisID());
+            builder.append("\" class=\"browseou\">");
+            builder.append(ou.getName());
+            builder.append("</a>");
+            builder.append(ouMetrics);
+            builder.append("</div>");
+            builder.append("<div id=\"collapse");
+            builder.append("outreemaker" + ouCounter);
+            builder.append("\" class=\"panel-collapse collapse\" role=\"tabpanel\" aria-labelledby=\"heading");
+            builder.append("outreemaker" + ouCounter);
+            builder.append("\"> <div class=\"panel-body list-child\">");
+
+            builder.append("<div class=\"panel-item\"><div class=\"panel-heading\" role=\"tab\" id=\"heading");
+            builder.append("outreemaker" + ouCounter);
+            builder.append("\">");
+            builder.append("<a href=\"../ou/");
+            builder.append(ou.getCrisID());
+            builder.append("\"class=\"org-tree-parent-org org-tree-item-link\"> ");
+            builder.append(ou.getName());
+            builder.append("</a>");
+            builder.append(ouMetrics.replaceAll("\\{\\{pubCount\\}\\}", "" + currentOU.pubCount).replaceAll("\\{\\{projCount\\}\\}", "" + currentOU.projCount).replaceAll("\\{\\{rpCount\\}\\}", "" + currentOU.rpCount));
+
+            builder.append("</div></div>");
+
+            for (OrganizationUnit child : children) {
+
+                ouCounter++;
+
+                OrganizationUnitWrapper childOU = createOuHierarchy(searchService, child, ous);
+                currentOU.pubCount += childOU.pubCount;
+                currentOU.projCount += childOU.projCount;
+                currentOU.rpCount += childOU.rpCount;
+                builder.append(childOU.asHTML);
+            }
+
+            builder.append("</div></div></div>");
+
+        } else if (children.size() <= 0) {
+            System.out.println("\t\"" + ou.getName() + "\" has no children");
+            builder.append("<div class=\"panel-item\"><div class=\"panel-heading\" role=\"tab\" id=\"heading");
+            builder.append("outreemaker" + ouCounter);
+            builder.append("\">");
+            builder.append("<a href=\"../ou/");
+            builder.append(ou.getCrisID());
+            builder.append("\" class=\"fas fa-orgunits org-tree-item-link\"> ");
+            builder.append(ou.getName());
+            builder.append("</a>");
+            builder.append(ouMetrics);
+            builder.append("</div></div>");
+
+        } else {
+            System.err.println("[ERROR] something went wrong with \"" + ou.getName()
+                    + "\": it seems not to be a top level organization unit nor a child (parent: \""
+                    + ou.getMetadata("parentorgunit") + "\", child-count: " + children.size() + ")");
+        }
+
+        ouCounter++;
+        currentOU.asHTML = builder.toString().replaceAll("\\{\\{pubCount\\}\\}", "" + currentOU.pubCount).replaceAll("\\{\\{projCount\\}\\}", "" + currentOU.projCount).replaceAll("\\{\\{rpCount\\}\\}", "" + currentOU.rpCount);
+        return currentOU;
+
+    }
+
+    /*
+     * Returns all children of corresponding organization unit.
+     */
+    private List<OrganizationUnit> getChildren(OrganizationUnit parentOu, List<OrganizationUnit> ous) {
+
+        List<OrganizationUnit> children = new LinkedList<>();
+
+        for (OrganizationUnit ou : ous) {
+            String parentName = ou.getMetadata("parentorgunit");
+            if (parentName != null && parentOu.getName().equals(parentName)) {
+                children.add(ou);
+            }
+        }
+
+        return children;
+
+    }
+    
+    private class OrganizationUnitWrapper {
+        
+        int pubCount = 0;
+        int rpCount = 0;
+        int projCount = 0;
+        String asHTML = "";
+        
+    }
+
+}

--- a/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/ExploreController.java
+++ b/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/ExploreController.java
@@ -24,6 +24,7 @@ import org.dspace.browse.BrowseDSpaceObject;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
+import org.dspace.app.cris.util.OrganizationUnitTreeMaker;
 import org.dspace.content.Item;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
@@ -50,6 +51,15 @@ public class ExploreController extends BaseAbstractController {
 
 		String configurationName = request.getPathInfo().substring("/explore/".length());
 		Context context = UIUtil.obtainContext(request);
+
+        /*
+         * Check for administrative POST requests
+         */
+        if ("POST".equals(request.getMethod()) && AuthorizeManager.isAdmin(context)) {
+            if(StringUtils.isNotEmpty(request.getParameter("update-ou-tree"))) {
+                OrganizationUnitTreeMaker.getInstance().updateOuTree();
+            }
+        }
 
 		DiscoveryConfiguration discoveryConfiguration = SearchUtils.getDiscoveryConfigurationByName(configurationName);
 

--- a/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/ImportFormController.java
+++ b/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/controller/ImportFormController.java
@@ -28,6 +28,7 @@ import org.dspace.app.cris.model.jdyna.DynamicObjectType;
 import org.dspace.app.cris.service.ApplicationService;
 import org.dspace.app.cris.util.ImportExportUtils;
 import org.dspace.app.cris.util.UtilsXSD;
+import org.dspace.app.cris.util.OrganizationUnitTreeMaker;
 import org.dspace.app.webui.cris.dto.ImportDTO;
 import org.dspace.app.webui.util.UIUtil;
 import org.dspace.authorize.AuthorizeManager;
@@ -147,6 +148,14 @@ public class ImportFormController  <ACO extends ACrisObject<P, TP, NP, NTP, ACNO
 									request.getLocale()));
 				}
 			}
+
+			/*
+			 * Update organization unit tree after successful import
+			 */
+			if("orgunit".equals(object.getType())) {
+			    OrganizationUnitTreeMaker.getInstance().updateOuTree();
+			}
+
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 			saveMessage(

--- a/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/servlet/OrganizationUnitTreeServlet.java
+++ b/dspace-cris/jspui-api/src/main/java/org/dspace/app/webui/cris/servlet/OrganizationUnitTreeServlet.java
@@ -1,0 +1,36 @@
+package org.dspace.app.webui.cris.servlet;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.sql.SQLException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.log4j.Logger;
+import org.dspace.app.cris.util.OrganizationUnitTreeMaker;
+import org.dspace.app.webui.servlet.DSpaceServlet;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.core.Context;
+
+public class OrganizationUnitTreeServlet extends DSpaceServlet
+{
+
+    private Logger log = Logger.getLogger(OrganizationUnitTreeServlet.class);
+    private OrganizationUnitTreeMaker treeMaker = OrganizationUnitTreeMaker.getInstance();
+
+    @Override
+    protected void doDSGet(Context context, HttpServletRequest request,
+            HttpServletResponse response) throws ServletException, IOException,
+            SQLException, AuthorizeException
+    {
+        response.setHeader("Content-Type", "text/html; charset=UTF-8");
+        
+        try(PrintWriter pw = response.getWriter()) {
+           pw.write(treeMaker.getTreeAsHTML());
+           pw.flush();
+        }
+    }
+
+}

--- a/dspace-cris/jspui-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/dspace-cris/jspui-webapp/src/main/webapp/WEB-INF/web.xml
@@ -1055,6 +1055,16 @@
     <url-pattern>/request-item</url-pattern>
   </servlet-mapping>
 
+  <servlet-mapping>
+      <servlet-name>get-organization-unit-tree</servlet-name>
+      <url-pattern>/getOrganizationUnitTree</url-pattern>
+  </servlet-mapping>
+
+  <servlet>
+      <servlet-name>get-organization-unit-tree</servlet-name>
+      <servlet-class>org.dspace.app.webui.cris.servlet.OrganizationUnitTreeServlet</servlet-class>
+  </servlet>
+
 	<!-- Icon MIME type -->
 	<mime-mapping>
 		<extension>ico</extension>

--- a/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/explore.jsp
+++ b/dspace-cris/jspui-webapp/src/main/webapp/dspace-cris/explore.jsp
@@ -92,6 +92,38 @@ function submitForm() {
 }
 
 -->
+var fetchOUTree = function() {
+	$.ajax({
+		url : "<%= request.getContextPath() %>/getOrganizationUnitTree",
+		contentType: "text/html; charset=utf-8",
+		beforeSend: function() {
+			$('#update-indicator').show();
+			$('#update-button').hide();
+		},
+		success: function(data) {
+			$('#organizationunittree').html(data);
+			$('#update-indicator').hide();
+			$('#update-button').show();
+		},
+		error: function(err) {
+			$('#organizationunittree').html("There was an error fetching the organization unit tree. Please contact the administrator.");
+			$('#update-indicator').hide();
+			$('#update-button').show();
+		}
+	});
+}
+
+var updateOUTree = function() {
+		$('#update-indicator').show();
+		$('#update-button').hide();
+		this.submit();
+}
+
+$(document).ready(function() {
+	if($('#location').val() === 'orgunits') {
+		fetchOUTree();
+	}
+})
 </script>
 </c:set>
 <c:set var="fmtkey">
@@ -207,6 +239,33 @@ function submitForm() {
 		</form>
 	</div>
 </div>
+<c:if test="${location=='orgunits'}">
+
+	<div class="panel panel-info">
+		<div class="panel-heading">
+			<div id='update-indicator' style="display: none;" class="loader pull-right"></div>
+
+	<%
+			if(((Boolean) request.getAttribute("is.admin")) != null && ((Boolean) request.getAttribute("is.admin")) == true) {
+	%>
+				<form style="padding-bottom: 5px;" method="post" action="<%= request.getContextPath() %>/cris/explore/orgunits">
+					<input type="hidden" name="update-ou-tree" value="true"/>
+					<input id="update-button" class="btn btn-info pull-right btn-sm" onclick="updateOUTree()" type="submit" name="submit" value="Update &#128472"/>
+				</form>
+	<%
+			}
+	%>
+
+			<h3 class="panel-title"><fmt:message key="jsp.browse.orgunits.tree" /></h3>
+		</div>
+		
+		<div id="organizationunittree">
+			The server is updating the organization unit tree...please wait.
+		</div>
+
+	</div>
+
+</c:if>
 <div class="clearfix"></div>
 	<div class="row">
 		<div class="col-sm-6">

--- a/dspace-jspui/src/main/webapp/static/css/bootstrap/dspace-theme.css
+++ b/dspace-jspui/src/main/webapp/static/css/bootstrap/dspace-theme.css
@@ -336,3 +336,32 @@ footer .container {
 	padding: 0;
 	float: left;
 }
+
+.org-tree-item-link {
+       margin: 5px;
+}
+
+/* Enable arrow change on accordion items */
+.panel-heading .accordion-toggle:before {
+       content: "\f107";
+}
+
+.panel-heading .accordion-toggle.collapsed:before {
+       content: "\f105";
+}
+/*
+ * General loading animation
+ */
+.loader {
+  display: inline-block;
+  border: 5px solid #f3f3f3; /* Light grey */
+  border-top: 5px solid #3498db; /* Blue */
+  border-radius: 50%;
+  width: 25px;
+  height: 25px;
+  animation: spin 1s linear infinite;
+}
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}


### PR DESCRIPTION
**Disclaimer:** This PR contains code for the organization unit tree described below composed from several mixed commits and might not be complete. This PR is for visibility reasons only due to requests. The first implementation had several shortcomings which were sometimes poorly patched so improvements and suggestions are welcome!

## Rationale
The University of Bamberg required a navigable list of their organization units.

![Peek 2019-12-04 14-34](https://user-images.githubusercontent.com/24757415/70146868-6482de80-16a3-11ea-8120-0bf9a028c111.gif)

## Features
- creates an entry for every *visible* organization unit
- creates a hierarchy if  valid `parentorgunit` is given ( `parentorgunit` must be a `text` field in `cris-configuration.xls`)
- is sorted if `priority` is given (`priority` must be a `text` field in `cris-configuration.xls`, `priority` is global and sorted alphanumeric)
- shows metrics about related *Publications*, *Researcher*, and *Projects*

## Missing Features
### No Multilingualism
Currently, multilingualism is not supported. We plan to implement this feature but there is no ETA.

### Not Time-Based Update
Since our DSpace instance is restarted regularly, there's no need for us to automatically update the organization unit tree.