### PR TITLE
[D4CRIS-899]Erroneous block code brackets

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/util/Authenticate.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/util/Authenticate.java
@@ -317,7 +317,6 @@ public class Authenticate
             if (shibbolethSpecialGroups != null) {
                 session.setAttribute("shib.specialgroup", shibbolethSpecialGroups);
             }
-        }
 
 			List<PostLoggedInAction> postLoggedInActions = new DSpace().getServiceManager().getServicesByType(
 					PostLoggedInAction.class);
@@ -329,6 +328,7 @@ public class Authenticate
 
 			}
 		
+        }
         context.setCurrentUser(eperson);
         
         boolean isAdmin = false;


### PR DESCRIPTION
Error in Authenticate.java class caused by anothet porting of commit of DSpace. This cause an NPE 
on all PostLoggedInAction.