### PR TITLE
Adding missing text

### DIFF
--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -3918,6 +3918,7 @@ jsp.home.explore.group-center-info = Repository other entities
 jsp.home.explore.group-right-info  = Publications, <small>books, articles...</small>
 
 jsp.home.group-right-info.publications = All Publications
+jsp.home.group-right-info.theses = All Theses
 jsp.home.group-right-info.datasets = All Datasets
 jsp.home.group-right-info.conferencematerials = All Conference materials
 


### PR DESCRIPTION
Adding missing "All Theses" text on main page's "Explore publications" menu item. The text is shown when at least one thesis is added in repository.