### PR TITLE
Show basic thumbnail if branded_preview bundle missing

### DIFF
--- a/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/DiscoveryArtifactTag.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/jsptag/DiscoveryArtifactTag.java
@@ -105,6 +105,11 @@ public class DiscoveryArtifactTag extends BodyTagSupport {
 				if (artifact.getType() == 2) {
 					Bundle[] bundles = ((Item) artifact).getBundles("BRANDED_PREVIEW");
 
+					// fallback to basic thumbnail bundle if branded_preview not available
+					if (bundles.length == 0) {
+						bundles = ((Item) artifact).getBundles("THUMBNAIL");
+					}
+
 					if (bundles.length > 0) {
 						Bitstream[] bitstreams = bundles[0].getBitstreams();
 


### PR DESCRIPTION
This allows that thumbnails are shown in discovery item lists (used in most viewed, most cited, recently added components), provided `<property name="thumbnail" value="true" />` is set in `dspace/config/spring/api/global-list-layout.xml` and that `webui.preview.enabled = true` in `dspace/config/dspace.cfg`