### PR TITLE
fixes path problem for projects in sitemap

### DIFF
--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/sitemap/CrisObjectsSitemapGenerator.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/sitemap/CrisObjectsSitemapGenerator.java
@@ -117,11 +117,11 @@ public class CrisObjectsSitemapGenerator implements ISitemapGeneratorPlugin
             }
             if (makeHTMLMap)
             {
-                html.addURL(url, null);
+                html.addURL(url, crisObj.getLastModified());
             }
             if (makeSitemapOrg)
             {
-                sitemapsOrg.addURL(url, null);
+                sitemapsOrg.addURL(url, crisObj.getLastModified());
             }
             applicationService.clearCache();
         }

--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/sitemap/CrisObjectsSitemapGenerator.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/sitemap/CrisObjectsSitemapGenerator.java
@@ -110,7 +110,7 @@ public class CrisObjectsSitemapGenerator implements ISitemapGeneratorPlugin
     {
         for (ACrisObject crisObj : crisObjects)
         {
-            String url = crisURLStem + crisObj.getAuthorityPrefix() + "/"
+            String url = crisURLStem + crisObj.getPublicPath() + "/"
                     + crisObj.getCrisID();
             if (BooleanUtils.isNotTrue(crisObj.getStatus())) {
                 continue;


### PR DESCRIPTION
In our sitemap the paths to projects are incorrect (there is a "pj" in the path instead of "project", cf https://tore.tuhh.de/sitemap?map=0). I believe I have found the problem in the code and have prepared a fix for that with this PR.