### PR TITLE
changes worktype mapping for Thesis to match ORCID API 3 requirements

### DIFF
--- a/dspace/config/crosswalks/mapConverter-orcid-worktype.properties
+++ b/dspace/config/crosswalks/mapConverter-orcid-worktype.properties
@@ -14,6 +14,6 @@ Recording,\ acoustical = artistic-performance
 Recording,\ musical = artistic-performance 
 Recording,\ oral = artistic-performance
 Technical\ Report = report
-Thesis = dissertation
+Thesis = dissertation-thesis
 Working\ Paper = working-paper
 Poster = conference-poster


### PR DESCRIPTION
For ORCID API version 3 a new type mapping for theses is required: https://info.orcid.org/documentation/integration-and-api-faq/#easy-faq-2682.

Thus this PR changes that mapping.