### PR TITLE
[D4CRIS-1119] Indexing add option to compare DB vs SOLR

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
@@ -130,6 +130,8 @@ public class IndexClient {
         
         options.addOption("e", "readfile", true, "Read the identifier from a file");
 
+        options.addOption("d", "diff", false, "Read the identifiers both from database and solr, diff the results and index it (default: item; use with -t to diff another class of entities)");
+        
         try {
             line = new PosixParser().parse(options, args);
         } catch (Exception e) {
@@ -166,6 +168,13 @@ public class IndexClient {
             indexer.optimize();
  		} else if(line.hasOption('s')) {
             checkRebuildSpellCheck(line, indexer);           
+        } else if (line.hasOption("d")) {
+        	log.info("Updating the missed objects");
+        	String optionValue = "2";
+        	if (line.hasOption("t")) { 
+        		optionValue = line.getOptionValue("t");
+        	}
+            indexer.diffIndex(context, Integer.valueOf(optionValue));
         } else if (line.hasOption("t")) {
         	log.info("Updating and Cleaning a specific Index");
             String optionValue = line.getOptionValue("t");			

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexingService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexingService.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 
 import org.dspace.browse.BrowsableDSpaceObject;
 import org.dspace.core.Context;
+import org.hibernate.Session;
 
 /**
  * Interface used for indexing BrowsableDSpaceObject into discovery
@@ -69,4 +70,7 @@ public interface IndexingService {
     void optimize() throws SearchServiceException;
 
     void buildSpellCheck() throws SearchServiceException;
+
+	void diffIndex(Context context, Integer type)  throws SQLException, SearchServiceException, IOException;
+	
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -47,6 +47,7 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.log4j.Logger;
 import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrQuery.ORDER;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrServer;
@@ -112,6 +113,7 @@ import org.dspace.handle.service.HandleService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.storage.rdbms.DatabaseUtils;
 import org.dspace.util.MultiFormatDateParser;
+import org.hibernate.Session;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -2696,5 +2698,99 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 			}
 		}
 	}
+	
+	@Override
+	public void diffIndex(Context context, Integer type)  throws SQLException, SearchServiceException, IOException {
+        if(type!=Constants.ITEM) {
+            throw new RuntimeException("Only ITEM is supported in this mode - type founded: " + type);
+        }
+        
+        //TODO Fix query error when returning uuid
+		List<Object[]> rows = getHibernateSession(context).createSQLQuery("select uuid as identifierobject from item where in_archive='1' or withdrawn='1' order by last_modified asc").list();
+    	prepareDiffAndReindex(context, type, "search.resourcetype:2", rows);
+    	
+	}
+
+	protected void prepareDiffAndReindex(Context context, Integer type, String fq, List<Object[]> rows)
+			throws SQLException, SearchServiceException, IOException {
+		System.out.println("Preparing diff...");
+		List<UUID> resultsDB = new ArrayList<UUID>();
+        
+		int countDB = 0;
+        for(Object[] row : rows) {
+        	UUID id = (UUID) row[0]; //.getIntColumn("identifierobject");
+        	resultsDB.add(id);
+        	countDB++;
+        	if(countDB%1000==0) {
+        		System.out.println(countDB);
+        	}
+        }
+
+        List<UUID> resultsSOLR = new ArrayList<UUID>();
+        
+		SolrQuery solrQuery = new SolrQuery();
+    	solrQuery.setQuery("*:*");
+    	solrQuery.setStart(0);
+    	solrQuery.setRows(Integer.MAX_VALUE);
+    	solrQuery.addFilterQuery("discoverable: true");
+    	solrQuery.addFilterQuery(fq);
+    	solrQuery.setFields("search.resourceid");
+    	solrQuery.setSort("lastModified", ORDER.asc);
+
+        QueryResponse response = search(solrQuery);
+        SolrDocumentList docList = response.getResults();
+        Iterator<SolrDocument> solrDoc = docList.iterator();
+        int countSOLR = 0;
+        while (solrDoc.hasNext())
+        {
+            SolrDocument doc = solrDoc.next();
+            UUID id = (UUID) doc
+                    .getFirstValue("search.resourceid");
+            resultsSOLR.add(id);
+            countSOLR++;
+        	if(countSOLR%1000==0) {
+        		System.out.println(countSOLR);
+        	}
+        }
+        
+        System.out.println("TOTAL DB:"+ countDB);
+        System.out.println("TOTAL SOLR:"+ countSOLR);
+        executeDiffAndReindex(context, type, resultsDB, resultsSOLR);
+	}
+	
+	protected void executeDiffAndReindex(Context context, Integer type, List<UUID> expectedrecords, List<UUID> actualrecords) throws IOException {
+		
+	    int linelength = -1;
+	    
+		List<UUID> unexpectedrecords = new ArrayList<UUID>();
+		
+	    if (expectedrecords.size() > actualrecords.size()) {
+	        linelength = expectedrecords.size();
+	    } else {
+	        linelength = actualrecords.size();
+	    }
+
+	    for (int i = 0; i < linelength; i++) {
+	        if (actualrecords.contains(expectedrecords.get(i))) {
+	            actualrecords.remove(expectedrecords.get(i));
+	        } else {
+	        	UUID item = expectedrecords.get(i);
+				log.info("Reindex Found type:" + type + " - objectID:" + item);
+	        	System.out.println("Reindex Found type:" + type + " - objectID:" + item);
+	            unexpectedrecords.add(item);
+	        }
+	    }
+	    if (unexpectedrecords.isEmpty())
+	    {
+	    	System.out.println("Nothing to update, exiting");
+	    	return;
+		}
+	    System.out.println("Update now...");
+		updateIndex(context, unexpectedrecords, true, type);
+	}
+	
+	protected static Session getHibernateSession(Context context) throws SQLException {
+        return ((Session) context.getDBConnection().getSession());
+    }
 	
 }

--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/discovery/CrisSearchService.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/discovery/CrisSearchService.java
@@ -1026,8 +1026,8 @@ public class CrisSearchService extends SolrServiceImpl
                 	fq = "search.resourcetype:11";
                 }
                 
-                List<Object[]> rows = getHibernateSession(context).createSQLQuery(query).list();
-            	prepareDiffAndReindex(context, type, fq, rows);
+                List<UUID> uuids = getHibernateSession(context).createSQLQuery(query).list();
+            	prepareDiffAndReindex(context, type, fq, uuids);
             }
             else
             {

--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/discovery/CrisSearchService.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/discovery/CrisSearchService.java
@@ -1026,7 +1026,7 @@ public class CrisSearchService extends SolrServiceImpl
                 	fq = "search.resourcetype:11";
                 }
                 
-                List<UUID> uuids = getHibernateSession(context).createSQLQuery(query).list();
+                List<String> uuids = getHibernateSession(context).createSQLQuery(query).list();
             	prepareDiffAndReindex(context, type, fq, uuids);
             }
             else


### PR DESCRIPTION
Checks whether DB contains items not indexed by Solr. 
Running the script allows to check and restore not indexed items 

Script execution:
./dspace index-discovery -d