### PR TITLE
FIX: database migrate ignore-missing without functionality

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -183,7 +183,7 @@ public class DatabaseUtils {
 
                     // "migrate" allows for an OPTIONAL second argument (only one may be specified):
                     //    - "ignored" = Also run any previously "ignored" migrations during the migration
-                    //    - "ignore-missing" = Ignore prviously "ignored" migrations during the migration
+                    //    - "ignore-missing" = Ignore "missing" migrations during the migration
                     //    - "force" = Even if no pending migrations exist, still run a migration to trigger callbacks.
                     //    - [version] = ONLY run migrations up to a specific DSpace version (ONLY FOR TESTING)
                     if (argv.length == 2) {
@@ -199,7 +199,7 @@ public class DatabaseUtils {
                                     "Migrating database to latest version ignoring \"Missing\" " +
                                         "migrations... (Check logs for details)");
                             // Update the database to latest version, but set "outOfOrder=true"
-                            // This will ensure any old migrations in the "ignored" state are now run
+                            // This will ensure any old migrations in the "missing" state are not run
                              updateDatabase(dataSource, connection, null, true, true);
                         } else if (argv[1].equalsIgnoreCase("force")) {
                              System.out.println(

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/DatabaseUtils.java
@@ -183,6 +183,7 @@ public class DatabaseUtils {
 
                     // "migrate" allows for an OPTIONAL second argument (only one may be specified):
                     //    - "ignored" = Also run any previously "ignored" migrations during the migration
+                    //    - "ignore-missing" = Ignore prviously "ignored" migrations during the migration
                     //    - "force" = Even if no pending migrations exist, still run a migration to trigger callbacks.
                     //    - [version] = ONLY run migrations up to a specific DSpace version (ONLY FOR TESTING)
                     if (argv.length == 2) {
@@ -199,7 +200,11 @@ public class DatabaseUtils {
                                         "migrations... (Check logs for details)");
                             // Update the database to latest version, but set "outOfOrder=true"
                             // This will ensure any old migrations in the "ignored" state are now run
+                             updateDatabase(dataSource, connection, null, true, true);
                         } else if (argv[1].equalsIgnoreCase("force")) {
+                             System.out.println(
+                                    "Migrating database to latest version AND \"Force\" " +
+                                        "migrations... (Check logs for details)");
                             updateDatabase(dataSource, connection, null, false, true);
                         } else {
                             // Otherwise, we assume "argv[1]" is a valid migration version number


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #[issue-number]
* Related to [REST Contract](https://github.com/DSpace/Rest7Contract)

## Description
Re-enable `database migrate ignore-missing` command, which has been removed in the last merge. 
Right now the command doesn't call the updateDatabase() method and thus does nothing at all.

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
- reintroduce updateDatabase() with previous parameters
- add sysout for force migration

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
