### PR TITLE
[TLC-277] Extend duplicate detection with new fuzzy search signature

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/deduplication/utils/FuzzyMetadataValueSignature.java
+++ b/dspace-api/src/main/java/org/dspace/app/deduplication/utils/FuzzyMetadataValueSignature.java
@@ -1,0 +1,204 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.deduplication.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
+import org.dspace.content.service.WorkspaceItemService;
+import org.dspace.core.Context;
+import org.dspace.workflow.WorkflowItemService;
+import org.dspace.workflow.factory.WorkflowServiceFactory;
+
+/**
+ * This signature will return search signatures that are transformed for use in solr filter queries with ~ max
+ * edit distance operators, and normalised for fuzzy search.
+ * "This Test Title" will be returned as thistesttitle~n
+ * (where 'n' is the max edit distance configured in spring)
+ *
+ * @author Kim Shepherd
+ */
+public class FuzzyMetadataValueSignature implements Signature {
+
+    /** log4j logger */
+    protected static Logger log = LogManager.getLogger(FuzzyMetadataValueSignature.class);
+
+    private String metadata;
+
+    private int resourceTypeID;
+
+    private String signatureType;
+
+    private int maxDistance;
+
+    protected List<String> ignorePrefix = new ArrayList<String>();
+
+    protected String prefix;
+
+    private String normalizationRegexp;
+
+    private boolean caseSensitive;
+
+    private boolean useCollection;
+
+    private boolean useEntityType = true;
+
+    private ItemService itemService;
+
+    protected WorkflowItemService<?> workflowItemService = WorkflowServiceFactory.getInstance()
+                                                                                 .getWorkflowItemService();
+
+    protected WorkspaceItemService  wsItemService = ContentServiceFactory.getInstance().getWorkspaceItemService();
+
+    /**
+     * This list of signatures is specifically intended for search filter values, NOT for inclusion
+     * in the _signature field when indexing the document
+     * @param item
+     * @param context
+     * @return
+     */
+    public List<String> getSearchSignature(DSpaceObject item, Context context) {
+        List<String> result = new ArrayList<>();
+        for (String signature: getSignature(item, context)) {
+            if (StringUtils.isNotEmpty(signature)) {
+                String searchFilterValue = signature + "~" + maxDistance;
+                if (!result.contains(searchFilterValue)) {
+                    result.add(searchFilterValue);
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * List of signatures intended for display, report, building and indexing Solr documents, etc.
+     * @param item
+     * @param context
+     * @return
+     */
+    public List<String> getSignature(DSpaceObject item, Context context) {
+        List<String> result = new ArrayList<>();
+        List<String> values = getMultiValue(item, metadata);
+        if (values != null) {
+            for (String value : values) {
+                if (StringUtils.isNotEmpty(value)) {
+                    // Normalisation - this should match the index plugin normalisation and handling
+                    // but only for the puporses of *indexed* or other uses of this signature.
+                    // For search query value handling, see getSearchSignature(...)
+                    String normValue = value.toLowerCase(Locale.ROOT)
+                            .replaceAll("\\s", "");
+                    result.add(normValue);
+                }
+            }
+        }
+        return result;
+
+    }
+
+    protected String getSingleValue(DSpaceObject item, String metadata) {
+        return ContentServiceFactory.getInstance().getDSpaceObjectService(item).getMetadata(item, metadata);
+    }
+
+    protected List<String> getMultiValue(DSpaceObject item, String metadata) {
+        List<MetadataValue> values = ContentServiceFactory.getInstance().getDSpaceObjectService(item)
+                .getMetadataByMetadataString(item, metadata);
+        ArrayList<String> retValue = new ArrayList<String>();
+
+        for (MetadataValue v : values) {
+            retValue.add(v.getValue());
+        }
+        return retValue;
+    }
+
+    public String getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(String metadata) {
+        this.metadata = metadata;
+    }
+
+    public int getResourceTypeID() {
+        return resourceTypeID;
+    }
+
+    public void setResourceTypeID(int resourceTypeID) {
+        this.resourceTypeID = resourceTypeID;
+    }
+
+    public List<String> getIgnorePrefix() {
+        return ignorePrefix;
+    }
+
+    public void setIgnorePrefix(List<String> ignorePrefix) {
+        this.ignorePrefix = ignorePrefix;
+    }
+
+    public String getSignatureType() {
+        return signatureType;
+    }
+
+    public void setSignatureType(String signatureType) {
+        this.signatureType = signatureType;
+    }
+
+    synchronized public ItemService getItemService() {
+        if (itemService == null) {
+            itemService = ContentServiceFactory.getInstance().getItemService();
+        }
+        return itemService;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String getNormalizationRegexp() {
+        return normalizationRegexp;
+    }
+
+    public void setNormalizationRegexp(String normalizationRegexp) {
+        this.normalizationRegexp = normalizationRegexp;
+    }
+
+    public boolean isUseCollection() {
+        return useCollection;
+    }
+
+    public void setUseCollection(boolean useCollection) {
+        this.useCollection = useCollection;
+    }
+
+    public boolean isUseEntityType() {
+        return useEntityType;
+    }
+
+    public void setUseEntityType(boolean useEntityType) {
+        this.useEntityType = useEntityType;
+    }
+
+    public int getMaxDistance() {
+        return maxDistance;
+    }
+
+    public void setMaxDistance(int maxDistance) {
+        this.maxDistance = maxDistance;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/app/deduplication/utils/MD5ValueSignature.java
+++ b/dspace-api/src/main/java/org/dspace/app/deduplication/utils/MD5ValueSignature.java
@@ -64,6 +64,20 @@ public class MD5ValueSignature implements Signature {
 
     protected WorkspaceItemService  wsItemService = ContentServiceFactory.getInstance().getWorkspaceItemService();
 
+    public List<String> getSearchSignature(DSpaceObject item, Context context) {
+        List<String> result = new ArrayList<>();
+        for (String signature: getSignature(item, context)) {
+            if (StringUtils.isNotEmpty(signature)) {
+                // Boost MD5 signature matches above others
+                String searchFilterValue = signature + "^5";
+                if (!result.contains(searchFilterValue)) {
+                    result.add(searchFilterValue);
+                }
+            }
+        }
+        return result;
+    }
+
     public List<String> getSignature(DSpaceObject item, Context context) {
         List<String> result = new ArrayList<String>();
         try {

--- a/dspace-api/src/main/java/org/dspace/app/deduplication/utils/Signature.java
+++ b/dspace-api/src/main/java/org/dspace/app/deduplication/utils/Signature.java
@@ -20,4 +20,6 @@ public interface Signature {
     public String getSignatureType();
 
     public String getMetadata();
+
+    public List<String> getSearchSignature(DSpaceObject item, Context context);
 }

--- a/dspace/config/spring/api/deduplication.xml
+++ b/dspace/config/spring/api/deduplication.xml
@@ -28,6 +28,16 @@
 		<property name="resourceTypeID" value="2" />
 	</bean>
 
+	<!-- Deduplication plugin to handle fuzzy search matches. Max distance is the maximum Levenshtein edit distance
+	when comparing metadata values. Whitespace is also stripped at index and query time. -->
+	<bean class="org.dspace.app.deduplication.utils.FuzzyMetadataValueSignature" name="FuzzyTitlePlugin">
+		<property name="normalizationRegexp" value="[^\p{L}]" />
+		<property name="signatureType" value="title" />
+		<property name="metadata" value="dc.title" />
+		<property name="resourceTypeID" value="2" />
+		<property name="maxDistance" value="1" />
+	</bean>
+
  	<bean class="org.dspace.app.deduplication.utils.MD5ValueSignature" name="ArXivSignature">
  		<property name="signatureType" value="identifier" />
 		<property name="metadata" value="dc.identifier.arxiv" />
@@ -113,6 +123,7 @@
 			</list>
 		</property>
 	</bean>
+
 	<bean class="org.dspace.app.deduplication.service.impl.ItemMetadataDedupServiceIndexPlugin" id="itemIdentifierSearchDeduplication">
 		<property name="metadata">
 			<list>


### PR DESCRIPTION
**Note:** This PR could be considered more of a proof-of-concept than a request for merge, though it should be 90% ready for merging to DSpace-CRIS 7 at this current stage, pending review.

This pull request introduces some extensions and improvements to the DSpace-CRIS deduplication framework, to add a new "fuzzy search" signature plugin and modify the Solr service and base Signature interface to better support cases where a signature value needs to be altered or handled in a special way in the Solr filter query or search query, but still indexed normally in the fake/match Solr documents.

* `Signature` interface has new `getSearchSignature` method which will return transformed signature strings for the purposes of finding matches in Solr
* `MD5Signature` implements the above method by appending a **^5** boost to search values, as both an example of usage and a useful way of prioritising exact MD5 signature matches
* `FuzzyMetadataValueSignature` implements the new method by appending a **~n** (where n is a configurable integer) max edit distance operator to the search values. It also lowercases and strips whitespace from both indexed and search signatures
* `SolrDedupService.fillSignature` populates the *tmpFilter* String List (used to find matches) with the `getSearchSignature` results (**tmpSearchMapFilter**), separately to populating the *tmpMapFilter* map used for building and indexing the fake/match/etc Solr documents
* `SolrDedupService.buildFromDedupReject` method signature changed to remove `tmpMapFilter, tmpFilter, searchSignature` as they are unused.

To review, make sure the detect duplicate step is configured for the appropriate submission process, and that the fuzzy match is configured in the deduplication spring config, and get some items into workspace. Try out titles that match existing titles by the edit distance, 1 more than the eidt distance, one below, eg.
* **Test Title** vs **Best Title** (with edit distance of 1)
* **Something Else** vs **Somethick Else** (with edit distance of 2)
* ....and so on 

## TODO?
* We might want to rename some variables (eg the tmp*Filter lists and maps) to better represent their usage
* Javadoc and tests, especially before opening PR for DSpace 7 if porting the entire feature
* Using normalizationRegexp instead of java for whitespace stripping in the fuzzy search signature?
* Any other improvements or useful implementation in the new signature to support other use cases

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
