### PR TITLE
introduces type mapping to COAR types for Scopus

### DIFF
--- a/dspace/config/crosswalks/mapConverter-scopusToCoarPublicationTypes.properties
+++ b/dspace/config/crosswalks/mapConverter-scopusToCoarPublicationTypes.properties
@@ -1,0 +1,14 @@
+ar = Resource Types::text::journal::journal article
+er = Resource Types::text::journal::journal article::corrigendum
+re = Resource Types::text::journal::journal article::review article
+cp = Resource Types::text::conference outputs::conference proceedings::conference paper
+bk = Resource Types::text::book
+ch = Resource Types::text::book chapter
+ed = Resource Types::text::journal::editorial
+le = Resource Types::text::letter
+cr = Conference Review
+ab = Abstract Report
+bz = Business Article
+no = Note
+pr = Press Release
+sh = Short Survey

--- a/dspace/config/spring/api/crosswalks.xml
+++ b/dspace/config/spring/api/crosswalks.xml
@@ -523,6 +523,7 @@
 				<entry key="orgUnitTypes" value-ref="mapConverterOrgUnitTypes" />
 				<entry key="accessRight" value-ref="mapConverterAccessRight" />
 				<entry key="coarToPublicationTypes" value-ref="mapConverterCoarToPublicationTypes" />
+				<entry key="scopusToCoarPublicationTypes" value-ref="mapConverterScopusToCoarPublicationTypes" />
 				<entry key="pubmedToCoarPublicationTypes" value-ref="mapConverterPubmedToCoarPublicationTypes" />
 				<entry key="cerifToOrgUnitTypes" value-ref="mapConverterCerifToOrgUnitTypes" />
 				<entry key="cerifToFundingTypes" value-ref="mapConverterCerifToFundingTypes" />
@@ -592,6 +593,12 @@
 
 	<bean name="mapConverterPubmedToCoarPublicationTypes" class="org.dspace.util.SimpleMapConverter" init-method="init">
 		<property name="converterNameFile" value="mapConverter-pubmedToCoarPublicationTypes.properties" />
+		<property name="configurationService" ref="org.dspace.services.ConfigurationService" />
+		<property name="defaultValue" value=""/>
+	</bean>
+
+	<bean name="mapConverterScopusToCoarPublicationTypes" class="org.dspace.util.SimpleMapConverter" init-method="init">
+		<property name="converterNameFile" value="mapConverter-scopusToCoarPublicationTypes.properties" />
 		<property name="configurationService" ref="org.dspace.services.ConfigurationService" />
 		<property name="defaultValue" value=""/>
 	</bean>

--- a/dspace/config/spring/api/scopus-integration.xml
+++ b/dspace/config/spring/api/scopus-integration.xml
@@ -19,7 +19,6 @@
         </description>
         <entry key-ref="scopus.doi" value-ref="scopusDoiContrib"/>
         <entry key-ref="scopus.title" value-ref="scopusTitleContrib"/>
-        <entry key-ref="scopus.type" value-ref="scopusTypeContrib"/>
         <entry key-ref="scopus.isbn" value-ref="scopusIsbnContrib"/>
         <entry key-ref="scopus.issn" value-ref="scopusIssnContrib"/>
         <entry key-ref="scopus.date" value-ref="scopusDateContrib"/>
@@ -32,6 +31,8 @@
         <entry key-ref="scopus.ispartof" value-ref="scopusIspartofContrib"/>
         <entry key-ref="scopus.ispartofseries" value-ref="scopusIspartofseriesContrib"/>
         <entry key-ref="scopus.authname" value-ref="scopusAuthorMetadataContrib"/>
+        <entry key-ref="scopus.mappedtype" value-ref="typeContrib"/>
+        <!--   <entry key-ref="scopus.type" value-ref="scopusTypeContrib"/>                -->
         <!--   <entry key-ref="scopus.source" value-ref="scopusSourceContrib"/>            -->
         <!--   <entry key-ref="scopus.abstract" value-ref="scopusAbstractContrib"/>        -->
         <!--   <entry key-ref="scopus.author" value-ref="scopusAuthorsContrib"/>           -->
@@ -197,6 +198,22 @@
 
     <bean id="scopus.ispartof" class="org.dspace.importer.external.metadatamapping.MetadataFieldConfig">
         <constructor-arg value="dc.relation.ispartof"/>
+    </bean>
+
+    <bean id="innerTypeContrib" class="org.dspace.importer.external.metadatamapping.contributor.SimpleXpathMetadatumContributor">
+        <property name="field" ref="scopus.mappedtype"/>
+        <property name="query" value="ns:subtype"/>
+        <property name="prefixToNamespaceMapping" ref="scopusNs"/>
+        <property name="metadataFieldMapping" ref="pubmedMetadataFieldMapping"/>
+    </bean>
+
+    <bean id="typeContrib" class="org.dspace.importer.external.metadatamapping.contributor.MappedMetadataContributor">
+        <constructor-arg name="innerContributor" ref="innerTypeContrib"/>
+        <constructor-arg name="mapConverter" ref="mapConverterScopusToCoarPublicationTypes"/>
+    </bean>
+
+    <bean id="scopus.mappedtype" class="org.dspace.importer.external.metadatamapping.MetadataFieldConfig">
+        <constructor-arg value="dc.type"/>
     </bean>
 
     <bean id="scopusIspartofseriesContrib" class="org.dspace.importer.external.metadatamapping.contributor.SimpleXpathMetadatumContributor">


### PR DESCRIPTION
## Description
This PR introduces type mapping for Scopus. The types coming in the scopus response are being mapped to DSpace-CRIS compliant COAR types.

## Instructions for Reviewers
No specific instructions, it's a simple configuration change.

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
