### PR TITLE
use metadata field dspace.object.owner instead of cris.owner in CRIS entity migration

### DIFF
--- a/dspace/etc/migration/entity_migration.ktr
+++ b/dspace/etc/migration/entity_migration.ktr
@@ -673,7 +673,7 @@
       <enabled>Y</enabled>
     </hop>
     <hop>
-      <from>add cris owner metadata field</from>
+      <from>add dspace object owner metadata field</from>
       <to>select metadata attributes 2</to>
       <enabled>Y</enabled>
     </hop>
@@ -689,7 +689,7 @@
     </hop>
     <hop>
       <from>owner not null</from>
-      <to>add cris owner metadata field</to>
+      <to>add dspace object owner metadata field</to>
       <enabled>Y</enabled>
     </hop>
     <hop>
@@ -2921,7 +2921,7 @@ WHERE property_def.id = properties.typo_id
     </GUI>
   </step>
   <step>
-    <name>add cris owner metadata field</name>
+    <name>add dspace object owner metadata field</name>
     <type>Constant</type>
     <description/>
     <distribute>Y</distribute>
@@ -2939,7 +2939,7 @@ WHERE property_def.id = properties.typo_id
         <currency/>
         <decimal/>
         <group/>
-        <nullif>cris</nullif>
+        <nullif>dspace</nullif>
         <length>-1</length>
         <precision>-1</precision>
         <set_empty_string>N</set_empty_string>
@@ -2951,7 +2951,7 @@ WHERE property_def.id = properties.typo_id
         <currency/>
         <decimal/>
         <group/>
-        <nullif>owner</nullif>
+        <nullif>object</nullif>
         <length>-1</length>
         <precision>-1</precision>
         <set_empty_string>N</set_empty_string>
@@ -2975,7 +2975,7 @@ WHERE property_def.id = properties.typo_id
         <currency/>
         <decimal/>
         <group/>
-        <nullif/>
+        <nullif>owner</nullif>
         <length>-1</length>
         <precision>-1</precision>
         <set_empty_string>N</set_empty_string>
@@ -6505,7 +6505,7 @@ WHERE property_def.id = properties.typo_id
       <method>none</method>
       <schema_name/>
     </partitioning>
-    <send_true_to>add cris owner metadata field</send_true_to>
+    <send_true_to>add dspace object owner metadata field</send_true_to>
     <send_false_to/>
     <compare>
       <condition>


### PR DESCRIPTION
## Description

DSpace 7.3 added the metadata schema change `REPLACE cris.owner with dspace.object.owner` in the Flyway script `V7.3_2022.09.28__Orcid_refactoring.sql`.

This change was not considered in the CRIS entity migration transformation (`entity_migration.ktr`). This leads to error messages (`ERROR: Metadata field: 'cris.owner.null' was not found in the registry.`) when running the CRIS entity migration process on DS-CRIS 2022.03.

## Instructions for Reviewers

- create a RP in a DS-CRIS 5.11 instance - make sure that the corresponding row in `cris_rpage` has a resolvable eperson ID in column `epersonid`
- apply migration to DS-CRIS 2022.03 as described in the DS-CRIS 2022.03 documentation
- run `ItemImportMainOA` via DS CLI
- the migration of the RP leads to the error message: `ERROR: Metadata field: 'cris.owner.null' was not found in the registry.`