### PR TITLE
fix CRIS project base path

### DIFF
--- a/dspace/etc/migration/entity_migration.ktr
+++ b/dspace/etc/migration/entity_migration.ktr
@@ -1341,7 +1341,7 @@ var file_main_dir = 'do-files';
 if(entity_type_var == 'OrgUnit'){
    file_main_dir = 'ou-files';
 } else if(entity_type_var == 'Project'){
-   file_main_dir = 'pj-files';
+   file_main_dir = 'rg-files';
 } else if(entity_type_var == 'Person'){
    file_main_dir = 'rp-files';
 }


### PR DESCRIPTION
## Description

By default, bitstreams of CRIS **projects** in DS-CRIS 5 are stored under `project.file.path = ${dspace.dir}/rg-files`, but the migration script asumes `pj-files`as the base directory.
