### PR TITLE
migration fix missing relationship values

### DIFF
--- a/dspace/etc/migration/relations_migrations.ktr
+++ b/dspace/etc/migration/relations_migrations.ktr
@@ -1004,6 +1004,14 @@ WHERE label = ?</sql>
         <column_name>left_place</column_name>
         <stream_name>left_place</stream_name>
       </field>
+      <field>
+        <column_name>leftward_value</column_name>
+        <stream_name>leftward_type</stream_name>
+      </field>
+      <field>
+        <column_name>rightward_value</column_name>
+        <stream_name>rightward_type</stream_name>
+      </field>
     </fields>
     <attributes/>
     <cluster_schema/>


### PR DESCRIPTION
## References
* Fixes https://github.com/4Science/DSpace/issues/329

## Description
Proper relationship entries after migration.

## Instructions for Reviewers
- both fields are already in the stream which is processed by the last step of pentahos relations_migration.ktr.
![Screenshot from 2023-04-28 10-06-58](https://user-images.githubusercontent.com/33422716/235094958-eb7f7eb0-8446-4614-8472-3e0d4edf34d0.png)
- to test: apply this specific migration step without this fields
- check table relationship;
- truncate table relationship;
- apply migration with this fields
- check table relationship;

List of changes in this PR:
- Add leftward_type into column leftward_value
- Add rightward_type into column rightward_type

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
