### PR TITLE
adds subject to subscription emails

### DIFF
--- a/dspace/config/emails/subscriptions_content
+++ b/dspace/config/emails/subscriptions_content
@@ -3,6 +3,7 @@
 ## Parameters: {0} Collections updates
 ##             {1} Communities updates
 ##             {2} Items updates
+#set($subject = 'DSpace: Your Content Subscriptions')
 
 This email is sent from DSpace-CRIS based on the chosen subscription preferences.
 


### PR DESCRIPTION
## References
* Related to #318 
* Addition to https://github.com/4Science/DSpace/commit/38c254a5f9ab3316ee077b346da0fe226f05b32f
* Related to https://github.com/DSpace/DSpace/pull/8772

## Description
While https://github.com/4Science/DSpace/commit/38c254a5f9ab3316ee077b346da0fe226f05b32f fixes the application of the subject to any email, there is still the subject parameter missing for subscription emails.
This PR adds a subject to the subscription email of contents.

## Instructions for Reviewers
It's just a minor PR for a configuration file, so I guess there are no instructions for reviewers needed.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
