### PR TITLE
fix typo in validation message of dc.title (person entity)

### DIFF
--- a/dspace/config/submission-forms.xml
+++ b/dspace/config/submission-forms.xml
@@ -1578,7 +1578,7 @@
           <label>Preferred Name</label>
           <input-type>name</input-type>
           <hint />
-          <required>You must enter least at the Surname.</required>
+          <required>You must enter at least the surname.</required>
         </field>
       </row>
       <row>


### PR DESCRIPTION
Fixed typo in `required` element.
