### PR TITLE
fix name of metadata field that contains collection name

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/batch/ItemImportOA.java
+++ b/dspace-api/src/main/java/org/dspace/app/batch/ItemImportOA.java
@@ -394,7 +394,7 @@ public class ItemImportOA {
                 }
 
                 System.out.println(
-                        owningPrefix + " Collection: " + collectionService.getMetadata(mycollections[i], "name"));
+                        owningPrefix + " Collection: " + collectionService.getMetadata(mycollections[i], "dc.title"));
             }
         } // end of validating collections
 


### PR DESCRIPTION
## Description

The name of a collection is stored in `dc.title`. The class `ItemImportOA` is using the field `name` instead.

This results in the output of

```
Destination collections:
Owning  Collection: null
```

when running the migration step `dspace dsrun org.dspace.app.batch.ItemImportMainOA -E <admin>`.
