### PR TITLE
Enable Solr core dedup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,7 @@ services:
     - ./dspace/solr/oai:/opt/solr/server/solr/configsets/oai
     - ./dspace/solr/search:/opt/solr/server/solr/configsets/search
     - ./dspace/solr/statistics:/opt/solr/server/solr/configsets/statistics
+    - ./dspace/solr/dedup:/opt/solr/server/solr/configsets/dedup
     # Keep Solr data directory between reboots
     - solr_data:/var/solr/data
     # Initialize all DSpace Solr cores using the mounted local configsets (see above), then start Solr
@@ -116,6 +117,8 @@ services:
       cp -r -u /opt/solr/server/solr/configsets/search/* search
       precreate-core statistics /opt/solr/server/solr/configsets/statistics
       cp -r -u /opt/solr/server/solr/configsets/statistics/* statistics
+      precreate-core dedup /opt/solr/server/solr/configsets/dedup
+      cp -r -u /opt/solr/server/solr/configsets/dedup/* dedup
       exec solr -f
 volumes:
   assetstore:


### PR DESCRIPTION
Due to changes in `DetectPotentialDuplicateValidator` the current CRIS release, 2023.01.00, does not work properly if the Solr core `dedup` is missing. This Solr core is one of 5 cores which are CRIS specific. 

Any "show edit form" request leads to HTTP response code 500 if `dedup` core is not available.

This PR adds the configuration of the missing Solr core `dedup`.

Additionally, I suggest to check the current form of exception handling in `DetectPotentialDuplicateValidator.findDuplicates` and do not throw a `RuntimeException` in case database or Solr server are not available to check for potential duplicates. This improvement will be addressed in a separate issue.