### PR TITLE
minor refactoring of ItemAuthorityLookupIndexPlugin: remove static variable

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/ItemAuthorityLookupIndexPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/ItemAuthorityLookupIndexPlugin.java
@@ -31,7 +31,7 @@ public class ItemAuthorityLookupIndexPlugin implements SolrServiceIndexPlugin {
 
     public static String ITEM_AUTHORITY_LOOKUP_INDEX = "itemauthoritylookup";
 
-    public static List<String> additionalFields;
+    private List<String> additionalFields;
 
     @SuppressWarnings("rawtypes")
     @Override
@@ -58,12 +58,12 @@ public class ItemAuthorityLookupIndexPlugin implements SolrServiceIndexPlugin {
             .collect(Collectors.toList());
     }
 
-    public static List<String> getAdditionalFields() {
+    public List<String> getAdditionalFields() {
         return additionalFields;
     }
 
-    public static void setAdditionalFields(List<String> additionalFields) {
-        ItemAuthorityLookupIndexPlugin.additionalFields = additionalFields;
+    public void setAdditionalFields(List<String> additionalFields) {
+        this.additionalFields = additionalFields;
     }
 
 }


### PR DESCRIPTION
## Description

IntelliJ is complaining about the field `additionalFields` in the `itemAuthorityLookupIndexPlugin` bean (see `discovery.xml`) as this field is declared as `public static` in `ItemAuthorityLookupIndexPlugin`. 

This PR changes `additionalFields` in `ItemAuthorityLookupIndexPlugin` to a private member variable.