### PR TITLE
added missing configuration to authority.cfg

### DIFF
--- a/dspace/config/modules/authority.cfg
+++ b/dspace/config/modules/authority.cfg
@@ -267,5 +267,7 @@ authority.controlled.dc.relation.ispartof = true
 authority.controlled.dc.type = true
 choices.plugin.dc.type = ControlledVocabularyAuthority
 
+authority.controlled.datacite.subject.fos = true
+
 # DSpace-CRIS stores by default the authority of controlled vocabularies
 vocabulary.plugin.authority.store = true


### PR DESCRIPTION
## References

This PR is related to https://github.com/4Science/DSpace/issues/347

## Description

Since the metadata field `datacite.subject.fos` is contained in the default submission forms provided by DS CRIS, the authority configuration should be adapted.