### PR TITLE
use authority instead of value for type-bind

### DIFF
--- a/dspace-api/src/main/java/org/dspace/validation/MetadataValidator.java
+++ b/dspace-api/src/main/java/org/dspace/validation/MetadataValidator.java
@@ -69,10 +69,10 @@ public class MetadataValidator implements SubmissionStepValidator {
         List<ValidationError> errors = new ArrayList<>();
 
         DCInputSet inputConfig = getDCInputSet(config);
-        String documentTypeValue = getDocumentTypeValue(obj);
+        String documentTypeAuthority = getDocumentTypeAuthority(obj);
 
         // Get list of all field names (including qualdrop names) allowed for this dc.type
-        List<String> allowedFieldNames = inputConfig.populateAllowedFieldNames(documentTypeValue);
+        List<String> allowedFieldNames = inputConfig.populateAllowedFieldNames(documentTypeAuthority);
 
         for (DCInput[] row : inputConfig.getFields()) {
             for (DCInput input : row) {
@@ -93,7 +93,7 @@ public class MetadataValidator implements SubmissionStepValidator {
 
                         // Check the lookup list. If no other inputs of the same field name allow this type,
                         // then remove. This includes field name without qualifier.
-                        if (!input.isAllowedFor(documentTypeValue) &&  (!allowedFieldNames.contains(fullFieldname)
+                        if (!input.isAllowedFor(documentTypeAuthority) &&  (!allowedFieldNames.contains(fullFieldname)
                                 && !allowedFieldNames.contains(input.getFieldName()))) {
                             removeMetadataValues(context, obj.getItem(), mdv);
                         } else {
@@ -118,18 +118,18 @@ public class MetadataValidator implements SubmissionStepValidator {
                 for (String fieldName : fieldsName) {
                     boolean valuesRemoved = false;
                     List<MetadataValue> mdv = itemService.getMetadataByMetadataString(obj.getItem(), fieldName);
-                    if (!input.isAllowedFor(documentTypeValue)) {
+                    if (!input.isAllowedFor(documentTypeAuthority)) {
                         // Check the lookup list. If no other inputs of the same field name allow this type,
                         // then remove. Otherwise, do not
                         if (!(allowedFieldNames.contains(fieldName))) {
                             removeMetadataValues(context, obj.getItem(), mdv);
                             valuesRemoved = true;
                             log.debug("Stripping metadata values for " + input.getFieldName() + " on type "
-                                    + documentTypeValue + " as it is allowed by another input of the same field " +
+                                    + documentTypeAuthority + " as it is allowed by another input of the same field " +
                                     "name");
                         } else {
                             log.debug("Not removing unallowed metadata values for " + input.getFieldName() + " on type "
-                                    + documentTypeValue + " as it is allowed by another input of the same field " +
+                                    + documentTypeAuthority + " as it is allowed by another input of the same field " +
                                     "name");
                         }
                     }
@@ -139,7 +139,7 @@ public class MetadataValidator implements SubmissionStepValidator {
                                                                 && !valuesRemoved) {
                         // Is the input required for *this* type? In other words, are we looking at a required
                         // input that is also allowed for this document type
-                        if (input.isAllowedFor(documentTypeValue)) {
+                        if (input.isAllowedFor(documentTypeAuthority)) {
                             // since this field is missing add to list of error
                             // fields
                             addError(errors, ERROR_VALIDATION_REQUIRED,
@@ -153,10 +153,10 @@ public class MetadataValidator implements SubmissionStepValidator {
         return errors;
     }
 
-    private String getDocumentTypeValue(InProgressSubmission<?> obj) {
+    private String getDocumentTypeAuthority(InProgressSubmission<?> obj) {
         String documentTypeField = configurationService.getProperty("submit.type-bind.field", "dc.type");
         List<MetadataValue> documentType = itemService.getMetadataByMetadataString(obj.getItem(), documentTypeField);
-        return documentType.size() > 0 ? documentType.get(0).getValue() : "";
+        return documentType.size() > 0 ? documentType.get(0).getAuthority() : "";
     }
 
     private DCInputSet getDCInputSet(SubmissionStepConfig config) {


### PR DESCRIPTION
In the current version of DSpace-CRIS-7, it is not possible to store values in MD fields that are associated with type-bind. This is because the `validate` method in `MetadataValidator.java` uses the value of DocumentType, but in DSpace-CRIS-7 the DocumentType is controlled by the controlled-vocabulary `publication-coar-types`. Therefore, the `validate` method must use the authority of the DocumentType.