### PR TITLE
delete all affected type-bind values when changing the type

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DSpaceRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DSpaceRestRepository.java
@@ -442,13 +442,14 @@ public abstract class DSpaceRestRepository<T extends RestAddressableModel, ID ex
         Context context = obtainContext();
         try {
             getThisRepository().patch(context, request, apiCategory, model, id, patch);
+            T ret = findById(id).orElse(null);
             context.commit();
+            return ret;
         } catch (AuthorizeException ae) {
             throw new RESTAuthorizationException(ae);
         } catch (SQLException e) {
             throw new RuntimeException(e.getMessage(), e);
         }
-        return findById(id).orElse(null);
     }
 
     /**


### PR DESCRIPTION
At least in DSpace CRIS 2023.01 there is a bug that when saving for the first time after changing from document type A to document type B when editing the metadata in the workflow area, MD fields associated with A via type-bind remain stored in the database. The following PR solves this issue by committing to the DB at a later time.
