### PR TITLE
improve migration of community subscriptions: set dspace_object_id to community UUID / remove community_id

### DIFF
--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.6_2023.07.20__subscription_add_dspace_object_ids_of_communities.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.6_2023.07.20__subscription_add_dspace_object_ids_of_communities.sql
@@ -1,0 +1,15 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-----------------------------------------------------------------------------------
+-- add community UUIDs to dspace_object_ids (in community subscriptions)
+-- remove column community_id afterwards
+-----------------------------------------------------------------------------------
+
+UPDATE subscription SET dspace_object_id = (SELECT uuid FROM community WHERE community_id = subscription.community_id) WHERE community_id IS NOT NULL;
+ALTER TABLE subscription DROP COLUMN community_id;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2023.07.20__subscription_add_dspace_object_ids_of_communities.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2023.07.20__subscription_add_dspace_object_ids_of_communities.sql
@@ -1,0 +1,15 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-----------------------------------------------------------------------------------
+-- add community UUIDs to dspace_object_ids (in community subscriptions)
+-- remove column community_id afterwards
+-----------------------------------------------------------------------------------
+
+UPDATE subscription SET dspace_object_id = (SELECT uuid FROM community WHERE community_id = subscription.community_id) WHERE community_id IS NOT NULL;
+ALTER TABLE subscription DROP COLUMN community_id;


### PR DESCRIPTION
This PR handles community subscriptions managed in the `subscription` table: it adds the community UUID to column `dspace_object_id`. This corresponds to the way new community subscriptions in DS CRIS are managed.

Afterward the column `community_id` in the `subscription` table is removed. This column was added with DSpace CRIS based on DSpace 1.8.2.2 (https://github.com/4Science/DSpace/blob/dspace-5_x_x-cris/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V1.8.2.2__DSpaceCRIS-subscription_database_schema.sql).