### PR TITLE
copy rightItem uuid only if there is some value to add

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/RelationshipPlacesIndexingServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/RelationshipPlacesIndexingServiceImpl.java
@@ -55,7 +55,9 @@ public class RelationshipPlacesIndexingServiceImpl implements RelationshipPlaces
                 if (singleDirectionRelationship("right", relationship.getRelationshipType())) {
                     times = relation.getLeftPlace() - relation.getRightPlace();
                 }
-                rightItemsIdsToAdd.addAll(Collections.nCopies(times, relation.getRightItem().getID().toString()));
+                if (times > 0) {
+                    rightItemsIdsToAdd.addAll(Collections.nCopies(times, relation.getRightItem().getID().toString()));
+                }
             }
             if (!rightItemsIdsToAdd.isEmpty()) {
 
@@ -79,7 +81,9 @@ public class RelationshipPlacesIndexingServiceImpl implements RelationshipPlaces
                 if (singleDirectionRelationship("left", relationship.getRelationshipType())) {
                     times = relation.getRightPlace() - relation.getLeftPlace();
                 }
-                leftItemsIdsToAdd.addAll(Collections.nCopies(times, relation.getLeftItem().getID().toString()));
+                if (times > 0) {
+                    leftItemsIdsToAdd.addAll(Collections.nCopies(times, relation.getLeftItem().getID().toString()));
+                }
             }
             if (!leftItemsIdsToAdd.isEmpty()) {
 
@@ -102,7 +106,9 @@ public class RelationshipPlacesIndexingServiceImpl implements RelationshipPlaces
             if (singleDirectionRelationship("right", relationship.getRelationshipType())) {
                 times = leftItemRelation.getLeftPlace() - leftItemRelation.getRightPlace();
             }
-            rightItemsToAdd.addAll(Collections.nCopies(times, leftItemRelation.getRightItem().getID().toString()));
+            if (times > 0) {
+                rightItemsToAdd.addAll(Collections.nCopies(times, leftItemRelation.getRightItem().getID().toString()));
+            }
         }
         if (!rightItemsToAdd.isEmpty())  {
             indexingService.updateRelationForItem(leftItem.getID().toString(),
@@ -122,7 +128,9 @@ public class RelationshipPlacesIndexingServiceImpl implements RelationshipPlaces
             if (singleDirectionRelationship("left", relationship.getRelationshipType())) {
                 times = leftItemRelation.getRightPlace() - leftItemRelation.getLeftPlace();
             }
-            rightItemsToAdd.addAll(Collections.nCopies(times, leftItemRelation.getLeftItem().getID().toString()));
+            if (times > 0) {
+                rightItemsToAdd.addAll(Collections.nCopies(times, leftItemRelation.getLeftItem().getID().toString()));
+            }
         }
         if (!rightItemsToAdd.isEmpty())  {
             indexingService.updateRelationForItem(rightItem.getID().toString(),


### PR DESCRIPTION
avoids exception in `Collections.nCopied` method when the calculated amount of rightItemstoAdd is below 0.

## References

* Fixes https://github.com/4Science/DSpace/issues/375 [#`issue-number` (if this fixes an issue ticket)](https://github.com/4Science/DSpace/issues/375)


## Description


## Instructions for Reviewers
- see issue for the way that causes the problem and how to reproduce it
- this fix solves the problem

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
