### PR TITLE
orcid profiles exclude non-public metadata 

### DIFF
--- a/dspace-api/src/main/java/org/dspace/orcid/model/factory/impl/OrcidSimpleValueObjectFactory.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/model/factory/impl/OrcidSimpleValueObjectFactory.java
@@ -42,6 +42,8 @@ public class OrcidSimpleValueObjectFactory extends AbstractOrcidProfileSectionFa
 
     private List<String> metadataFields = new ArrayList<String>();
 
+    private boolean isAllowedMetadataVisibility = false;
+
     public OrcidSimpleValueObjectFactory(OrcidProfileSectionType sectionType, OrcidProfileSyncPreference preference) {
         super(sectionType, preference);
     }
@@ -76,6 +78,7 @@ public class OrcidSimpleValueObjectFactory extends AbstractOrcidProfileSectionFa
     public List<String> getMetadataSignatures(Context context, Item item) {
         return metadataFields.stream()
             .flatMap(metadataField -> getMetadataValues(item, metadataField).stream())
+            .filter(metadataValue -> getAllowedMetadataVisibility(metadataValue))
             .map(metadataValue -> metadataSignatureGenerator.generate(context, List.of(metadataValue)))
             .collect(Collectors.toList());
     }
@@ -137,6 +140,13 @@ public class OrcidSimpleValueObjectFactory extends AbstractOrcidProfileSectionFa
         return address;
     }
 
+    private boolean getAllowedMetadataVisibility(MetadataValue metadataValue) {
+        if (isAllowedMetadataVisibility()) {
+            return metadataValue.getSecurityLevel() == null || metadataValue.getSecurityLevel() == 0;
+        }
+        return true;
+    }
+
     public void setMetadataFields(String metadataFields) {
         this.metadataFields = metadataFields != null ? asList(metadataFields.split(",")) : emptyList();
     }
@@ -146,4 +156,11 @@ public class OrcidSimpleValueObjectFactory extends AbstractOrcidProfileSectionFa
         return metadataFields;
     }
 
+    public boolean isAllowedMetadataVisibility() {
+        return isAllowedMetadataVisibility;
+    }
+
+    public void setAllowedMetadataVisibility(boolean allowedMetadataVisibility) {
+        isAllowedMetadataVisibility = allowedMetadataVisibility;
+    }
 }

--- a/dspace/config/spring/api/orcid-services.xml
+++ b/dspace/config/spring/api/orcid-services.xml
@@ -112,6 +112,7 @@
 					<property name="roleField" value="${orcid.mapping.affiliation.role}" />
 					<property name="startDateField" value="${orcid.mapping.affiliation.start-date}" />
 					<property name="endDateField" value="${orcid.mapping.affiliation.end-date}" />
+					<!-- <property name="allowedMetadataVisibility" value="true" /> -->
 				</bean>
 				
     			<bean class="org.dspace.orcid.model.factory.impl.OrcidAffiliationFactory">
@@ -121,6 +122,7 @@
 					<property name="roleField" value="${orcid.mapping.qualification.role}" />
 					<property name="startDateField" value="${orcid.mapping.qualification.start-date}" />
 					<property name="endDateField" value="${orcid.mapping.qualification.end-date}" />
+					<!-- <property name="allowedMetadataVisibility" value="true" /> -->
 				</bean>
 				
     			<bean class="org.dspace.orcid.model.factory.impl.OrcidAffiliationFactory">
@@ -130,36 +132,42 @@
 					<property name="roleField" value="${orcid.mapping.education.role}" />
 					<property name="startDateField" value="${orcid.mapping.education.start-date}" />
 					<property name="endDateField" value="${orcid.mapping.education.end-date}" />
+					<!-- <property name="allowedMetadataVisibility" value="true" /> -->
 				</bean>
 				
     			<bean class="org.dspace.orcid.model.factory.impl.OrcidSimpleValueObjectFactory">
 					<constructor-arg name="sectionType" value="OTHER_NAMES" />
 					<constructor-arg name="preference" value="BIOGRAPHICAL" />
 					<property name="metadataFields" value="${orcid.mapping.other-names}" />
+					<!-- <property name="allowedMetadataVisibility" value="true" /> -->
 				</bean>
 				
     			<bean class="org.dspace.orcid.model.factory.impl.OrcidSimpleValueObjectFactory">
 					<constructor-arg name="sectionType" value="KEYWORDS" />
 					<constructor-arg name="preference" value="BIOGRAPHICAL" />
 					<property name="metadataFields" value="${orcid.mapping.keywords}" />
+					<!-- <property name="allowedMetadataVisibility" value="true" /> -->
 				</bean>
 				
     			<bean class="org.dspace.orcid.model.factory.impl.OrcidSimpleValueObjectFactory">
 					<constructor-arg name="sectionType" value="COUNTRY" />
 					<constructor-arg name="preference" value="BIOGRAPHICAL" />
 					<property name="metadataFields" value="${orcid.mapping.country}" />
+					<!-- <property name="allowedMetadataVisibility" value="true" /> -->
 				</bean>
 				
     			<bean class="org.dspace.orcid.model.factory.impl.OrcidPersonExternalIdentifierFactory">
 					<constructor-arg name="sectionType" value="EXTERNAL_IDS" />
 					<constructor-arg name="preference" value="IDENTIFIERS" />
 					<property name="externalIds" value="${orcid.mapping.person-external-ids}" />
+					<!-- <property name="allowedMetadataVisibility" value="true" /> -->
 				</bean>
 				
     			<bean class="org.dspace.orcid.model.factory.impl.OrcidSimpleValueObjectFactory">
 					<constructor-arg name="sectionType" value="RESEARCHER_URLS" />
 					<constructor-arg name="preference" value="IDENTIFIERS" />
 					<property name="metadataFields" value="${orcid.mapping.researcher-urls}" />
+					<!-- <property name="allowedMetadataVisibility" value="true" /> -->
 				</bean>
 				
     		</list>


### PR DESCRIPTION
…adata security level/visibility before calculating the metadata signature for orcid profile objects

## References
* Fixes https://github.com/4Science/DSpace/issues/393 #`394` (if this fixes an issue ticket)

## Description
Short summary of changes (1-2 sentences).
configurable option to exclude non-public metadata based on their metadata security level/visibility before calculating the metadata signature for orcid profile objects.

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* introduced configurable option which returns true when the metadata security level is null or 0 . The parameter is some boolean which can be added to the ObjectFactory generating the orcid Profile Section element. By default it is disabled.
* before the list of metadata for the orcid metadata signature is being created each of the metadata values is being checked.  
* this prevents metadata with security level 1 (group access) or 2 (owner/administrator) from pushing hidden metadata by mistake  

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ x If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
