### PR TITLE
Skip processing in EmbeddablePlumXMetricProvider as soon as possible

### DIFF
--- a/dspace-api/src/main/java/org/dspace/metrics/embeddable/impl/EmbeddablePlumXMetricProvider.java
+++ b/dspace-api/src/main/java/org/dspace/metrics/embeddable/impl/EmbeddablePlumXMetricProvider.java
@@ -139,6 +139,10 @@ public class EmbeddablePlumXMetricProvider extends AbstractEmbeddableMetricProvi
 
     @Override
     public boolean hasMetric(Context context, Item item, List<CrisMetrics> retrivedStoredMetrics) {
+        if (!super.hasMetric(context, item, retrivedStoredMetrics)) {
+            return false;
+        }
+        
         String entityType = getEntityType(item);
         if (entityType != null) {
             if (entityType.equals("Person")) {
@@ -162,8 +166,6 @@ public class EmbeddablePlumXMetricProvider extends AbstractEmbeddableMetricProvi
                     }
                 }
             }
-        } else {
-            return false;
         }
         return false;
     }


### PR DESCRIPTION
## Description

Currently, the method `hasMetric` in `EmbeddablePlumXMetricProvider` does **not** check the return value of `isEnabled()`. This PR adds this check by calling the `hasMetric` method of the base class.