### PR TITLE
authorize-check for xlscollectionCrosswalk

### DIFF
--- a/dspace/config/spring/api/crosswalks.xml
+++ b/dspace/config/spring/api/crosswalks.xml
@@ -509,7 +509,14 @@
 		<property name="crosswalkMode" value="#{T(org.dspace.content.crosswalk.CrosswalkMode).MULTIPLE}"/>
 	</bean>
 	
-	<bean class="org.dspace.content.integration.crosswalks.XlsCollectionCrosswalk" id="xlsCrosswalkCollection"/>
+	<bean class="org.dspace.content.integration.crosswalks.XlsCollectionCrosswalk" id="xlsCrosswalkCollection">
+		<property name="allowedGroups">
+			<list>
+				<value>Administrator</value>
+				<value>Anonymous</value>
+			</list>
+		</property>
+	</bean>
 
     <bean class="org.dspace.content.integration.crosswalks.ZipItemExportCrosswalk" id="zipCrosswalk">
         <property name="zipName" value="items.zip"/>


### PR DESCRIPTION
## References
* Fixes https://github.com/4Science/DSpace/issues/422

## Description
Implement interface method for fine granular check to export these crosswalks to specific groups

## Instructions for Reviewers

List of changes in this PR:
* implement isAuthorized method, which was before by default true by the interface `ItemExportCrosswalk`
  * add group check copied from other Crosswalk Formats
* whitebox-Tests: depending on the configuration check if the crosswalk format is offered to Anonymous/Administrator users in the context-menu.
* Introduced new IntegrationTest to check the isAuthorized function
* configuration: allow access to Administrator and Anonymous (behavior as before)

```
	<bean class="org.dspace.content.integration.crosswalks.XlsCollectionCrosswalk" id="xlsCrosswalkCollection">
		<property name="allowedGroups">
			<list>
				<value>Administrator</value>
				<value>Anonymous</value>
			</list>
		</property>
	</bean>
```

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
