### PR TITLE
COAR NotifyService IT failures: NotifyServiceInboundPatternsRemoveOpe…

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/ldn/NotifyServiceInboundPatternsRemoveOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/ldn/NotifyServiceInboundPatternsRemoveOperation.java
@@ -66,6 +66,6 @@ public class NotifyServiceInboundPatternsRemoveOperation extends PatchOperation<
         String path = operation.getPath().trim();
         return (objectToMatch instanceof NotifyServiceEntity &&
             operation.getOp().trim().equalsIgnoreCase(OPERATION_REMOVE) &&
-            path.startsWith(OPERATION_PATH));
+            path.startsWith(OPERATION_PATH) && path.endsWith(OPERATION_PATH));
     }
 }


### PR DESCRIPTION
Bug issue at [DSpace github](https://github.com/DSpace/DSpace/issues/9457)

All **NotifyServiceInboundPatternsRemove*IT** classes has the _supports()_ method: returning true, the class is used to manage the incoming patch request. This boolean is calculated by matching the path sting to the string _/notifyServiceInboundPatterns_ . This path is used as the initial part of many NotifyServiceInboundPattern*Operation classes. 

_org.dspace.app.rest.repository.patch.operation.ldn.NotifyServiceInboundPatternsRemoveOperation_
is the backend service to delete all the inboundPatterns of a given notifyServiceEntity. **It's supports() method is evaluated as true**   even if the http patch call had the path   _/notifyServiceInboundPatterns[1]/constraint_  - and it is wrong because the correct backend to be triggered should be **org.dspace.app.rest.repository.patch.operation.ldn.NotifyServiceInboundPatternConstraintRemoveOperation**

That said - the solution is to add the condition 
`&& path.endsWith(OPERATION_PATH)`
to the supports() method return condition on _NotifyServiceInboundPatternsRemoveOperation_ class.