### PR TITLE
skip indexing of metadatavalue with security level

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceMetadataBrowseIndexingPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceMetadataBrowseIndexingPlugin.java
@@ -125,8 +125,20 @@ public class SolrServiceMetadataBrowseIndexingPlugin implements SolrServiceIndex
                                                                                     Boolean.FALSE),
                                                        true);
 
+                            // the maximum security level (if not null) which ist still indexed
+                            Integer maxsecuritylevel = DSpaceServicesFactory
+                                .getInstance()
+                                .getConfigurationService()
+                                .getIntProperty("discovery.index.securitylevel.maxlevel", 0);
+
+
                             for (int x = 0; x < values.size(); x++) {
                                 MetadataValue val = values.get(x);
+
+                                if (val.getSecurityLevel() != null && val.getSecurityLevel() > maxsecuritylevel) {
+                                    continue;
+                                }
+
                                 boolean hasChoiceAuthority = choiceAuthorityService
                                         .isChoicesConfigured(metadataAuthorityService
                                                 .makeFieldKey(val.getSchema(), val.getElement(), val.getQualifier())

--- a/dspace-api/src/main/java/org/dspace/discovery/indexobject/ItemIndexFactoryImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/indexobject/ItemIndexFactoryImpl.java
@@ -316,6 +316,11 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
                 }
             }
 
+            Integer maxsecuritylevel = DSpaceServicesFactory
+                .getInstance()
+                .getConfigurationService()
+                .getIntProperty("discovery.index.securitylevel.maxlevel", 0);
+
             List<String> toIgnoreMetadataFields = SearchUtils.getIgnoredMetadataFields(item.getType());
             List<MetadataValue> mydc = itemService.getMetadata(item, Item.ANY, Item.ANY, Item.ANY, Item.ANY);
             for (MetadataValue meta : mydc) {
@@ -337,6 +342,11 @@ public class ItemIndexFactoryImpl extends DSpaceObjectIndexFactoryImpl<Indexable
                 //We are not indexing provenance, this is useless
                 if (toIgnoreMetadataFields != null && (toIgnoreMetadataFields.contains(field) || toIgnoreMetadataFields
                         .contains(unqualifiedField + "." + Item.ANY))) {
+                    continue;
+                }
+
+                // We are not indexing values with security level greater than the maximum value
+                if (meta.getSecurityLevel() != null && meta.getSecurityLevel() > maxsecuritylevel) {
                     continue;
                 }
 

--- a/dspace-api/src/test/java/org/dspace/discovery/DiscoveryIT.java
+++ b/dspace-api/src/test/java/org/dspace/discovery/DiscoveryIT.java
@@ -8,6 +8,10 @@
 package org.dspace.discovery;
 
 import static org.dspace.discovery.SolrServiceWorkspaceWorkflowRestrictionPlugin.DISCOVER_WORKSPACE_CONFIGURATION_NAME;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -21,6 +25,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocument;
 import org.dspace.AbstractIntegrationTestWithDatabase;
 import org.dspace.app.launcher.ScriptLauncher;
 import org.dspace.app.scripts.handler.impl.TestDSpaceRunnableHandler;
@@ -98,6 +106,9 @@ public class DiscoveryIT extends AbstractIntegrationTestWithDatabase {
 
     MetadataAuthorityService metadataAuthorityService = ContentAuthorityServiceFactory.getInstance()
                                                                                       .getMetadataAuthorityService();
+
+    SolrSearchCore solrSearchCore = DSpaceServicesFactory.getInstance().getServiceManager()
+        .getServicesByType(SolrSearchCore.class).get(0);
 
     @Override
     @Before
@@ -796,6 +807,108 @@ public class DiscoveryIT extends AbstractIntegrationTestWithDatabase {
         assertFalse(lastModifieds.isEmpty());
         for (int i = 1; i < lastModifieds.size() - 1; i++) {
             assertTrue(lastModifieds.get(i).compareTo(lastModifieds.get(i + 1)) >= 0);
+        }
+    }
+
+    /**
+     * Test designed to check if metadatavalues with securitylevel are indexed.
+     * @throws SearchServiceException
+     */
+    @Test
+    public void searchWithMaxSecurityLevelSetTest() throws SearchServiceException {
+
+        configurationService.setProperty("discovery.index.securitylevel.maxlevel", 0);
+        DiscoveryConfiguration defaultConf = SearchUtils.getDiscoveryConfiguration(context, "default", null);
+
+        // Populate the testing objects: create items in eperson's workspace and perform search in it
+        int numberItems = 10;
+        context.turnOffAuthorisationSystem();
+        EPerson submitter = null;
+        try {
+            submitter = EPersonBuilder.createEPerson(context).withEmail("submitter@example.org")
+                .withNameInMetadata("Peter", "Funny").build();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        context.setCurrentUser(submitter);
+        Community community = CommunityBuilder.createCommunity(context).build();
+        Collection collection = CollectionBuilder.createCollection(context, community).build();
+        for (int i = 0; i < numberItems; i++) {
+            ItemBuilder.createItem(context, collection)
+                .withTitle("item " + i)
+                .withSecuredMetadata("dc", "description", "abstract", "secured" + i + ".", 1)
+                .withSecuredMetadata("dc", "description", "abstract", "secured" + i + ".", 2)
+                .withSecuredMetadata("dc", "description", "abstract", "nonsecured" + i + ".", 0)
+                .build();
+        }
+        context.restoreAuthSystemState();
+
+        // Build query with default parameters (except for workspaceConf)
+        QueryResponse result = null;
+        try {
+            result = solrSearchCore.getSolr().query(new SolrQuery(String.format(
+                "search.resourcetype:\"Item\"")));
+        } catch (SolrServerException e) {
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        assertEquals(result.getResults().size(), numberItems);
+        for (SolrDocument doc : result.getResults()) {
+            assertThat(doc.getFieldNames(), hasItem("dc.description.abstract"));
+            assertThat(doc.getFieldValues("dc.description.abstract"), not(hasItem(startsWith("secured"))));
+            assertThat(doc.getFieldValues("dc.description.abstract"), hasItem(startsWith("nonsecured")));
+        }
+    }
+
+    /**
+     * Test designed to check if metadatavalues with securitylevel greater than 0 are indexed.
+     * @throws SearchServiceException
+     */
+    @Test
+    public void searchWithMaxSecurityLevelGreater1SetTest() throws SearchServiceException {
+
+        configurationService.setProperty("discovery.index.securitylevel.maxlevel", 1);
+        DiscoveryConfiguration defaultConf = SearchUtils.getDiscoveryConfiguration(context, "default", null);
+
+        // Populate the testing objects: create items in eperson's workspace and perform search in it
+        int numberItems = 10;
+        context.turnOffAuthorisationSystem();
+        EPerson submitter = null;
+        try {
+            submitter = EPersonBuilder.createEPerson(context).withEmail("submitter@example.org")
+                .withNameInMetadata("Peter", "Funny").build();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        context.setCurrentUser(submitter);
+        Community community = CommunityBuilder.createCommunity(context).build();
+        Collection collection = CollectionBuilder.createCollection(context, community).build();
+        for (int i = 0; i < numberItems; i++) {
+            ItemBuilder.createItem(context, collection)
+                .withTitle("item " + i)
+                .withSecuredMetadata("dc", "description", "abstract", "nonsecured" + i + ".", 1)
+                .withSecuredMetadata("dc", "description", "abstract", "secured" + i + ".", 2)
+                .withSecuredMetadata("dc", "description", "abstract", "nonsecured" + i + ".", 0)
+                .build();
+        }
+        context.restoreAuthSystemState();
+
+        // Build query with default parameters (except for workspaceConf)
+        QueryResponse result = null;
+        try {
+            result = solrSearchCore.getSolr().query(new SolrQuery(String.format(
+                "search.resourcetype:\"Item\"")));
+        } catch (SolrServerException e) {
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        assertEquals(result.getResults().size(), numberItems);
+        for (SolrDocument doc : result.getResults()) {
+            assertThat(doc.getFieldNames(), hasItem("dc.description.abstract"));
+            assertThat(doc.getFieldValues("dc.description.abstract"), not(hasItem(startsWith("secured"))));
+            assertThat(doc.getFieldValues("dc.description.abstract"), hasItem(startsWith("nonsecured")));
         }
     }
 

--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -57,3 +57,6 @@ discovery.facet.namedtype.workflow.pooled = 004workflow\n|||\nWaiting for Contro
 # Set to -1 if stale objects should be ignored. Set to 0 if you want to avoid extra query but take the chance to cleanup 
 # the index each time that stale objects are found. Default 3
 discovery.removestale.attempts = 3
+
+# the maximum securitylevel of metadatavalues which is still indexed. All above are skipped
+discovery.index.securitylevel.maxlevel = 0


### PR DESCRIPTION
## References
* Fixes #452 


## Description
New configuration value `discovery.index.securitylevel.maxlevel`. All (non-null) securitylevel above this value are skipped during indexing. The default value is 0.

## Instructions for Reviewers

List of changes in this PR:
* added configuration
* added check in itemindex factory to skip metadatavalues with some security level greater than the expected limit
* added two Integation Tests to check if the metadatavalue is indexed.

**Include guidance for how to test or review your PR.** 
- create some metadatavalue with security level and try to search them using the discovery

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
