### PR TITLE
DataCiteConnector: remove unused static variables

### DIFF
--- a/dspace-api/src/main/java/org/dspace/identifier/doi/DataCiteConnector.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/DataCiteConnector.java
@@ -69,14 +69,6 @@ public class DataCiteConnector
     // Configuration property names
     static final String CFG_USER = "identifier.doi.user";
     static final String CFG_PASSWORD = "identifier.doi.password";
-    static final String CFG_PREFIX
-        = "identifier.doi.prefix";
-    static final String CFG_PUBLISHER
-        = "crosswalk.dissemination.DataCite.publisher";
-    static final String CFG_DATAMANAGER
-        = "crosswalk.dissemination.DataCite.dataManager";
-    static final String CFG_HOSTINGINSTITUTION
-        = "crosswalk.dissemination.DataCite.hostingInstitution";
     static final String CFG_NAMESPACE
         = "crosswalk.dissemination.DataCite.namespace";
 


### PR DESCRIPTION
## Description

This PR removes 4 unused static variables in `DataCiteConnector`.