### PR TITLE
DIM2DataCite.xsl: update XML namespace to DataCite kernel version 4

### DIFF
--- a/dspace/config/crosswalks/DIM2DataCite.xsl
+++ b/dspace/config/crosswalks/DIM2DataCite.xsl
@@ -11,7 +11,7 @@
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:dspace="http://www.dspace.org/xmlns/dspace/dim"
-                xmlns="http://datacite.org/schema/kernel-3"
+                xmlns="http://datacite.org/schema/kernel-4"
                 version="2.0">
     
     <!-- CONFIGURATION -->
@@ -47,9 +47,9 @@
             properties are in the metadata of the item to export.
             The classe named above respects this.
         -->
-        <resource xmlns="http://datacite.org/schema/kernel-3"
-                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xsi:schemaLocation="http://datacite.org/schema/kernel-3 http://schema.datacite.org/meta/kernel-3/metadata.xsd">
+        <resource xmlns="http://datacite.org/schema/kernel-4"
+                  xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
             <!--
                 MANDATORY PROPERTIES


### PR DESCRIPTION
## Description

`DIM2DataCite.xsl` uses schema elements, e.g. `givenName` and `familyName`, that were added in DataCite kernel version 4 (http://schema.datacite.org/meta/kernel-4/metadata.xsd). 

Currently, the XSL stylesheet `DIM2DataCite.xsl` refers to kernel version 3 (http://schema.datacite.org/meta/kernel-3/metadata.xsd) that does not contain `givenName` and `familyName`.
