### PR TITLE
Remove obsolete top-level element version in Docker Compose yml files

### DIFF
--- a/docker-compose-cli.yml
+++ b/docker-compose-cli.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   dspace-cli:
     image: "${DOCKER_OWNER:-dspace}/dspace-cli:${DSPACE_VER:-dspace-7_x}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 networks:
   dspacenet:
     ipam:

--- a/dspace/src/main/docker-compose/cli.assetstore.yml
+++ b/dspace/src/main/docker-compose/cli.assetstore.yml
@@ -5,9 +5,6 @@
 #
 # http://www.dspace.org/license/
 #
-
-version: "3.7"
-
 services:
   dspace-cli:
     environment:

--- a/dspace/src/main/docker-compose/cli.ingest.yml
+++ b/dspace/src/main/docker-compose/cli.ingest.yml
@@ -5,9 +5,6 @@
 #
 # http://www.dspace.org/license/
 #
-
-version: "3.7"
-
 services:
   dspace-cli:
     environment:

--- a/dspace/src/main/docker-compose/db.entities.yml
+++ b/dspace/src/main/docker-compose/db.entities.yml
@@ -5,9 +5,6 @@
 #
 # http://www.dspace.org/license/
 #
-
-version: "3.7"
-
 services:
   dspacedb:
     image: dspace/dspace-postgres-pgcrypto:dspace-7_x-loadsql

--- a/dspace/src/main/docker-compose/db.restore.yml
+++ b/dspace/src/main/docker-compose/db.restore.yml
@@ -5,10 +5,6 @@
 #
 # http://www.dspace.org/license/
 #
-
-version: "3.7"
-
-#
 # Overrides the default "dspacedb" container behavior to load a local SQL file into PostgreSQL.
 #
 # This can be used to restore a "dspacedb" container from a pg_dump, or during upgrade to a new version of PostgreSQL.

--- a/dspace/src/main/docker-compose/docker-compose-angular.yml
+++ b/dspace/src/main/docker-compose/docker-compose-angular.yml
@@ -5,8 +5,6 @@
 #
 # http://www.dspace.org/license/
 #
-
-version: '3.7'
 networks:
   dspacenet:
 services:

--- a/dspace/src/main/docker-compose/docker-compose-iiif.yml
+++ b/dspace/src/main/docker-compose/docker-compose-iiif.yml
@@ -10,7 +10,6 @@
 # Test environment for DSpace + Cantaloupe for IIIF support. See README for instructions.
 # This should NEVER be used in production scenarios.
 #
-version: '3.7'
 networks:
   dspacenet:
 services:

--- a/dspace/src/main/docker-compose/docker-compose-shibboleth.yml
+++ b/dspace/src/main/docker-compose/docker-compose-shibboleth.yml
@@ -10,7 +10,6 @@
 # Test environment for DSpace + Shibboleth (running via mod_shib in Apache). See README for instructions.
 # This should NEVER be used in production scenarios.
 #
-version: '3.7'
 networks:
   dspacenet:
 services:


### PR DESCRIPTION
## Description

This RP removes the top-level `version` element in all Docker Compose specifications.

The element `version` is obsolete (reference document: https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-optional)