### PR TITLE
replace hard-coded file path separators

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/I18nUtil.java
+++ b/dspace-api/src/main/java/org/dspace/core/I18nUtil.java
@@ -234,7 +234,7 @@ public class I18nUtil {
         String fileName = "";
         final String FILE_TYPE = ".xml";
         String defsFilename = DSpaceServicesFactory.getInstance().getConfigurationService().getProperty("dspace.dir")
-                              + File.separator + "config/controlled-vocabularies/" + File.separator + vocabularyName;
+                              + File.separator + "config" + File.separator + "controlled-vocabularies" + File.separator + vocabularyName;
         fileName = getFilename(locale, defsFilename, FILE_TYPE);
         return fileName;
     }


### PR DESCRIPTION
## Description

This PR replaces hard-coded file path separators (`/`) in `org.dspace.core.I18nUtil` to improve interoperability.
