### PR TITLE
fixes #473: avoid NPE for items without bitstreams and bundles

### DIFF
--- a/dspace-api/src/main/java/org/dspace/versioning/ItemCorrectionProvider.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/ItemCorrectionProvider.java
@@ -191,30 +191,31 @@ public class ItemCorrectionProvider extends AbstractVersionProvider {
 
     protected void updateBundlesAndBitstreams(Context c, Item itemNew, Item nativeItem)
             throws SQLException, AuthorizeException, IOException {
+        if (bundles != null && bundles.size() > 0) {
+            for (String bundleName : bundles) {
+                List<Bundle> nativeBundles = nativeItem.getBundles(bundleName);
+                List<Bundle> correctedBundles = itemNew.getBundles(bundleName);
 
-        for (String bundleName : bundles) {
-            List<Bundle> nativeBundles = nativeItem.getBundles(bundleName);
-            List<Bundle> correctedBundles = itemNew.getBundles(bundleName);
+                if (CollectionUtils.isEmpty(nativeBundles) && CollectionUtils.isEmpty(correctedBundles)) {
+                    continue;
+                }
 
-            if (CollectionUtils.isEmpty(nativeBundles) && CollectionUtils.isEmpty(correctedBundles)) {
-                continue;
+                Bundle nativeBundle;
+                if (CollectionUtils.isEmpty(nativeBundles)) {
+                    nativeBundle = bundleService.create(c, nativeItem, bundleName);
+                } else {
+                    nativeBundle = nativeBundles.get(0);
+                }
+
+                Bundle correctedBundle;
+                if (CollectionUtils.isEmpty(correctedBundles)) {
+                    correctedBundle = bundleService.create(c, nativeItem, bundleName);
+                } else {
+                    correctedBundle = correctedBundles.get(0);
+                }
+
+                updateBundleAndBitstreams(c, nativeBundle, correctedBundle);
             }
-
-            Bundle nativeBundle;
-            if (CollectionUtils.isEmpty(nativeBundles)) {
-                nativeBundle = bundleService.create(c, nativeItem, bundleName);
-            } else {
-                nativeBundle = nativeBundles.get(0);
-            }
-
-            Bundle correctedBundle;
-            if (CollectionUtils.isEmpty(correctedBundles)) {
-                correctedBundle = bundleService.create(c, nativeItem, bundleName);
-            } else {
-                correctedBundle = correctedBundles.get(0);
-            }
-
-            updateBundleAndBitstreams(c, nativeBundle, correctedBundle);
         }
     }
 


### PR DESCRIPTION
## References
* Fixes #473 

## Description
This PR adds a check for bundles before looping through them as this would cause an NPE.

## Instructions for Reviewers
No instructions - its a very simple PR.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
