### PR TITLE
omit placeholders for external identifiers

### DIFF
--- a/dspace-api/src/main/java/org/dspace/orcid/model/factory/impl/OrcidProductWorkFactory.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/model/factory/impl/OrcidProductWorkFactory.java
@@ -202,7 +202,10 @@ public class OrcidProductWorkFactory implements OrcidEntityFactory {
     private ExternalID getSelfExternalId(MetadataValue metadataValue) {
         Map<String, String> externalIdentifierFields = fieldMapping.getExternalIdentifierFields();
         String metadataField = metadataValue.getMetadataField().toString('.');
-        return getExternalId(externalIdentifierFields.get(metadataField), metadataValue.getValue(), SELF);
+        if (isNotPlaceholder(metadataValue)) {
+            return getExternalId(externalIdentifierFields.get(metadataField), metadataValue.getValue(), SELF);
+        }
+        return null;
     }
 
     private List<ExternalID> getWorkFundedByExternalIds(Context context, Item item) {

--- a/dspace-api/src/main/java/org/dspace/orcid/model/factory/impl/OrcidWorkFactory.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/model/factory/impl/OrcidWorkFactory.java
@@ -203,7 +203,10 @@ public class OrcidWorkFactory implements OrcidEntityFactory {
     private ExternalID getSelfExternalId(MetadataValue metadataValue) {
         Map<String, String> externalIdentifierFields = fieldMapping.getExternalIdentifierFields();
         String metadataField = metadataValue.getMetadataField().toString('.');
-        return getExternalId(externalIdentifierFields.get(metadataField), metadataValue.getValue(), SELF);
+        if (isNotPlaceholder(metadataValue)) {
+            return getExternalId(externalIdentifierFields.get(metadataField), metadataValue.getValue(), SELF);
+        }
+        return null;
     }
 
     private List<ExternalID> getWorkFundedByExternalIds(Context context, Item item) {


### PR DESCRIPTION
## References
* Fixes #490 

## Description
This PR solves the problem, that a placeholder may be submitted to ORCID.

## Instructions for Reviewers
The problem occurs, when you want to push an item to ORCID.

List of changes in this PR:
* Omit an external ID if it's just a placeholder


## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
