### PR TITLE
Removal of deprecated jmx configuration in solrconfig.xml of Solr cores dedup and audit

### DIFF
--- a/dspace/solr/audit/conf/solrconfig.xml
+++ b/dspace/solr/audit/conf/solrconfig.xml
@@ -41,8 +41,6 @@
     <infoStream>true</infoStream>
   </indexConfig>
 
-  <jmx />
-
   <updateHandler class="solr.DirectUpdateHandler2">
 
     <updateLog>

--- a/dspace/solr/dedup/conf/solrconfig.xml
+++ b/dspace/solr/dedup/conf/solrconfig.xml
@@ -311,25 +311,6 @@
      <infoStream>true</infoStream>
   </indexConfig>
 
-
-  <!-- JMX
-       
-       This example enables JMX if and only if an existing MBeanServer
-       is found, use this if you want to configure JMX through JVM
-       parameters. Remove this to disable exposing Solr configuration
-       and statistics to JMX.
-
-       For more details see http://wiki.apache.org/solr/SolrJmx
-    -->
-  <jmx />
-  <!-- If you want to connect to a particular server, specify the
-       agentId 
-    -->
-  <!-- <jmx agentId="myAgent" /> -->
-  <!-- If you want to start a new MBeanServer, specify the serviceUrl -->
-  <!-- <jmx serviceUrl="service:jmx:rmi:///jndi/rmi://localhost:9999/solr"/>
-    -->
-
   <!-- The default high-performance update handler -->
   <updateHandler class="solr.DirectUpdateHandler2">
 


### PR DESCRIPTION
## Description

This minor PR removes the deprecated `jmx` configuration in `solrconfig.xml`.
