### PR TITLE
set correctionTypes as optional dependency in CorrectionTypeServiceImpl

### DIFF
--- a/dspace-api/src/main/java/org/dspace/correctiontype/service/impl/CorrectionTypeServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/correctiontype/service/impl/CorrectionTypeServiceImpl.java
@@ -26,7 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class CorrectionTypeServiceImpl implements CorrectionTypeService {
 
-    @Autowired
+    @Autowired(required = false)
     private List<CorrectionType> correctionTypes;
 
     @Override


### PR DESCRIPTION
## Problem Description

This PR fixes a bug which is caused by a missing dependency in `CorrectionTypeServiceImpl`. We see this error on application startup:

```
2025-02-26 11:47:17 Field correctionTypes in org.dspace.correctiontype.service.impl.CorrectionTypeServiceImpl required a bean of type 'java.util.List' that could not be found.
2025-02-26 11:47:17 
2025-02-26 11:47:17 The injection point has the following annotations:
2025-02-26 11:47:17     - @org.springframework.beans.factory.annotation.Autowired(required=true)
2025-02-26 11:47:17 
2025-02-26 11:47:17 
2025-02-26 11:47:17 Action:
2025-02-26 11:47:17 
2025-02-26 11:47:17 Consider defining a bean of type 'java.util.List' in your configuration.
2025-02-26 11:47:17 
```

The required dependency should be transformed to an optional dependency since `core-services.xml` does not contain a `correctionTypes` list.


