### PR TITLE
Respect scope in required field validation for hidden/readonly fields

### DIFF
--- a/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/item-submission.xml
@@ -33,6 +33,7 @@
         <name-map collection-entity-type="CustomEntityType" submission-name="entitytypetest"/>
         <name-map collection-handle="123456789/test-duplicate-detection" submission-name="test-duplicate-detection"/>
         <name-map collection-handle="123456789/collection-test-patch" submission-name="publicationTestPatch"/>
+        <name-map collection-handle="123456789/test-metadata-validator" submission-name="test-metadata-validator"/>
     </submission-map>
 
 
@@ -319,6 +320,13 @@
             <processing-class>org.dspace.app.rest.submit.step.NotifyStep</processing-class>
             <type>coarnotify</type>
         </step-definition>
+
+        <step-definition id="test-metadata-validator-step">
+            <heading></heading>
+            <processing-class>org.dspace.app.rest.submit.step.DescribeStep</processing-class>
+            <type>collection</type>
+        </step-definition>
+
         <step-definition id="upload-no-required-metadata" mandatory="true">
             <heading>submit.progressbar.upload-no-required-metadata</heading>
             <processing-class>org.dspace.app.rest.submit.step.UploadStep</processing-class>
@@ -541,6 +549,10 @@
             <step id="collection"/>
             <step id="duplicates"/>
             <step id="traditionalpageone"/>
+        </submission-process>
+
+        <submission-process name="test-metadata-validator">
+            <step id="test-metadata-validator-step"/>
         </submission-process>
 
         <submission-process name="publicationTestPatch">

--- a/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
@@ -2450,6 +2450,78 @@ it, please enter the types and the actual numbers or codes.</hint>
              </field>
          </row>
      </form>
+     <form name="test-metadata-validator-step">
+         <row>
+             <field>
+                 <dc-schema>dc</dc-schema>
+                 <dc-element>title</dc-element>
+                 <repeatable>false</repeatable>
+                 <label>Title</label>
+                 <input-type>onebox</input-type>
+                 <required>Title is required</required>
+                 <hint>Enter the title of the item</hint>
+             </field>
+             <field>
+                 <dc-schema>dc</dc-schema>
+                 <dc-element>contributor</dc-element>
+                 <dc-qualifier>author</dc-qualifier>
+                 <repeatable>true</repeatable>
+                 <label>Author(s)</label>
+                 <input-type>onebox</input-type>
+                 <required>Author is required</required>
+                 <hint>Enter the author(s) of the item</hint>
+                 <readonly>workflow</readonly>
+             </field>
+             <field>
+                 <dc-schema>dc</dc-schema>
+                 <dc-element>date</dc-element>
+                 <dc-qualifier>issued</dc-qualifier>
+                 <repeatable>false</repeatable>
+                 <label>Date Issued</label>
+                 <input-type>date</input-type>
+                 <required>Date issued is required</required>
+                 <hint>Enter the date the item was issued</hint>
+                 <visibility>submission</visibility>
+                 <readonly>submission</readonly>
+             </field>
+         </row>
+         <row>
+             <field>
+                 <dc-schema>dc</dc-schema>
+                 <dc-element>description</dc-element>
+                 <dc-qualifier>abstract</dc-qualifier>
+                 <repeatable>false</repeatable>
+                 <label>Abstract</label>
+                 <input-type>textarea</input-type>
+                 <required>Abstract is required</required>
+                 <hint>Enter an abstract for the item</hint>
+                 <visibility>workflow</visibility>
+                 <readonly>submission</readonly>
+             </field>
+             <field>
+                 <dc-schema>dc</dc-schema>
+                 <dc-element>subject</dc-element>
+                 <repeatable>true</repeatable>
+                 <label>Subject(s)</label>
+                 <input-type>onebox</input-type>
+                 <required>Subject is required</required>
+                 <hint>Enter subject keywords for the item</hint>
+                 <visibility>workflow</visibility>
+                 <readonly>workflow</readonly>
+             </field>
+             <field>
+                 <dc-schema>dc</dc-schema>
+                 <dc-element>type</dc-element>
+                 <repeatable>false</repeatable>
+                 <label>Type</label>
+                 <input-type>onebox</input-type>
+                 <required>Type is required</required>
+                 <hint>Enter the type of the item</hint>
+                 <visibility>submission</visibility>
+                 <readonly>all</readonly>
+             </field>
+         </row>
+     </form>
  </form-definitions>
 
 

--- a/dspace-api/src/test/java/org/dspace/validation/MetadataValidatorIT.java
+++ b/dspace-api/src/test/java/org/dspace/validation/MetadataValidatorIT.java
@@ -1,0 +1,176 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.validation;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.app.util.DCInputsReader;
+import org.dspace.app.util.SubmissionConfig;
+import org.dspace.app.util.SubmissionConfigReader;
+import org.dspace.app.util.SubmissionStepConfig;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.WorkflowItemBuilder;
+import org.dspace.builder.WorkspaceItemBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.WorkspaceItem;
+import org.dspace.content.authority.factory.ContentAuthorityServiceFactory;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.validation.model.ValidationError;
+import org.dspace.workflow.WorkflowItem;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Integration test for {@link MetadataValidator} to ensure it respects
+ * readonly and hidden scopes for required fields.
+ *
+ * This test class relies on a custom submission definition ("test-metadata-validator")
+ * which must be configured in dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml and
+ * dspace-api/src/test/data/dspaceFolder/config/item-submission.xml.
+ *
+ */
+public class MetadataValidatorIT extends AbstractIntegrationTestWithDatabase {
+
+    private Collection collection;
+    private MetadataValidator validator;
+    private SubmissionStepConfig submissionStepConfig;
+    private ItemService itemService = ContentServiceFactory.getInstance().getItemService();
+    private ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        context.turnOffAuthorisationSystem();
+
+        Community community = CommunityBuilder.createCommunity(context).build();
+        collection = CollectionBuilder.createCollection(context, community)
+            .withSubmissionDefinition("test-metadata-validator")
+            .build();
+
+        context.restoreAuthSystemState();
+
+        SubmissionConfigReader submissionConfigReader = new SubmissionConfigReader();
+        SubmissionConfig submissionConfig = submissionConfigReader.getSubmissionConfigByCollection(collection);
+        // Assumes the test submission process has one step defined
+        submissionStepConfig = submissionConfig.getStep(0);
+
+        validator = new MetadataValidator();
+        validator.setName("test-validator");
+        validator.setItemService(itemService);
+        validator.setMetadataAuthorityService(ContentAuthorityServiceFactory.getInstance()
+            .getMetadataAuthorityService());
+        validator.setConfigurationService(configurationService);
+        validator.setInputReader(new DCInputsReader());
+    }
+
+    /**
+     * In SUBMISSION scope, ensures validation reports only required fields
+     * not marked readonly/hidden for submission. Missing dc.title and
+     * dc.contributor.author should be flagged; dc.date.issued is ignored.
+     */
+    @Test
+    public void testValidationInSubmissionScopeWithErrors() throws Exception {
+        context.turnOffAuthorisationSystem();
+        WorkspaceItem wsi = WorkspaceItemBuilder.createWorkspaceItem(context, collection).build();
+        context.restoreAuthSystemState();
+
+        List<ValidationError> errors = validator.validate(context, wsi, submissionStepConfig);
+
+        assertThat(errors, hasSize(1));
+
+        List<String> errorPaths = getErrorPaths(errors);
+        assertThat(errorPaths, containsInAnyOrder(
+            "/sections/test-metadata-validator-step/dc.title",
+            "/sections/test-metadata-validator-step/dc.contributor.author"
+        ));
+    }
+
+    /**
+     * In SUBMISSION scope, ensures no errors when all required fields
+     * for this scope are present. Fields readonly/hidden in submission
+     * can remain empty without errors.
+     */
+    @Test
+    public void testValidationInSubmissionScopeWithoutErrors() throws Exception {
+        context.turnOffAuthorisationSystem();
+        WorkspaceItem wsi = WorkspaceItemBuilder.createWorkspaceItem(context, collection)
+            .withTitle("Test Title")
+            .withAuthor("Test, Author")
+            .withIssueDate("2025-08-14")
+            .build();
+        context.restoreAuthSystemState();
+
+        List<ValidationError> errors = validator.validate(context, wsi, submissionStepConfig);
+
+        assertThat(errors, empty());
+    }
+
+    /**
+     * In WORKFLOW scope, ensures validation reports only required fields
+     * not marked readonly/hidden for workflow. Missing dc.title and
+     * dc.description.abstract should be flagged; others are ignored.
+     */
+    @Test
+    public void testValidationInWorkflowScopeWithErrors() throws Exception {
+        context.turnOffAuthorisationSystem();
+        WorkflowItem wfi = WorkflowItemBuilder.createWorkflowItem(context, collection).build();
+        context.restoreAuthSystemState();
+
+        List<ValidationError> errors = validator.validate(context, wfi, submissionStepConfig);
+
+        assertThat(errors, hasSize(1));
+
+        List<String> errorPaths = getErrorPaths(errors);
+        assertThat(errorPaths, containsInAnyOrder(
+            "/sections/test-metadata-validator-step/dc.title",
+            "/sections/test-metadata-validator-step/dc.description.abstract"
+        ));
+    }
+
+    /**
+     * In WORKFLOW scope, ensures no errors when all required fields
+     * for this scope are present. Fields readonly/hidden in workflow
+     * can remain empty without errors.
+     */
+    @Test
+    public void testValidationInWorkflowScopeWithoutErrors() throws Exception {
+        context.turnOffAuthorisationSystem();
+        WorkflowItem wfi = WorkflowItemBuilder.createWorkflowItem(context, collection).build();
+
+        // Add metadata for fields required in the workflow scope
+        itemService.addMetadata(context, wfi.getItem(), "dc", "title", null, null, "Test Title");
+        itemService.addMetadata(context, wfi.getItem(), "dc", "description", "abstract", null, "Test Abstract");
+        itemService.addMetadata(context, wfi.getItem(), "dc", "subject", null, null, "Test Subject");
+
+        context.restoreAuthSystemState();
+
+        List<ValidationError> errors = validator.validate(context, wfi, submissionStepConfig);
+
+        assertThat(errors, empty());
+    }
+
+    private List<String> getErrorPaths(List<ValidationError> errors) {
+        return errors.stream()
+            .flatMap(error -> error.getPaths().stream())
+            .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
Ensure required field validation respects scope restrictions.
- Updated MetadataValidator to check current scope before enforcing required fields
- Skipped validation for fields marked hidden/readonly in the active scope
- Adjusted and added tests for scope-aware validation behavior
- Added test form definitions with scope declarations

## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #520 

## Description
Fix required field validation to respect scope restrictions. Validation now ignores required checks when the field is hidden or readonly in the current scope.

## Instructions for Reviewers
This PR ensures metadata validation aligns with submission workflows by considering scope.

List of changes in this PR:

* Updated MetadataValidator to check scope before validating required fields
* Skipped validation for fields marked hidden/readonly in the active scope
* Adjusted existing tests to cover scope-aware validation
* Added new test form definitions with scope declarations

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
