### PR TITLE
Fix: Determine workflow configuration by checking group assignment

### DIFF
--- a/dspace-api/src/main/java/org/dspace/workflow/WorkflowItemService.java
+++ b/dspace-api/src/main/java/org/dspace/workflow/WorkflowItemService.java
@@ -123,9 +123,7 @@ public interface WorkflowItemService<T extends WorkflowItem> extends InProgressS
      * @param  collection   the collection to check
      * @return              true if the given collection has a workflow configured,
      *                      false otherwise
-     * @throws SQLException An exception that provides information on a database
-     *                      access error or other errors.
      */
-    public boolean isWorkflowConfigured(Context context, Collection collection) throws SQLException;
+    boolean isWorkflowConfigured(Context context, Collection collection);
 
 }

--- a/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/XmlWorkflowItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/xmlworkflow/storedcomponents/XmlWorkflowItemServiceImpl.java
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Collection;
 import org.dspace.content.Item;
+import org.dspace.content.service.CollectionService;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
 import org.dspace.core.LogHelper;
@@ -55,6 +56,8 @@ public class XmlWorkflowItemServiceImpl implements XmlWorkflowItemService {
     protected WorkflowItemRoleService workflowItemRoleService;
     @Autowired(required = true)
     protected GroupService groupService;
+    @Autowired(required = true)
+    protected CollectionService collectionService;
 
     /*
      * The current step in the workflow system in which this workflow item is present
@@ -218,16 +221,19 @@ public class XmlWorkflowItemServiceImpl implements XmlWorkflowItemService {
      * Check if a WORKFLOW_ROLE group related to the given collection exists.
      */
     @Override
-    public boolean isWorkflowConfigured(Context context, Collection collection) throws SQLException {
+    public boolean isWorkflowConfigured(Context context, Collection collection) {
 
         if (collection == null) {
             return false;
 
         }
 
-        String groupName = "COLLECTION_" + collection.getID() + "_WORKFLOW_ROLE";
-        Group workflowRoleGroup = groupService.findByNamePrefix(context, groupName);
-
-        return workflowRoleGroup != null && !groupService.isEmpty(workflowRoleGroup);
+        for (int i = 1; i <= 3; i++) {
+            Group workflowGroup = collectionService.getWorkflowGroup(context, collection, i);
+            if (workflowGroup != null) {
+                return !groupService.isEmpty(workflowGroup);
+            }
+        }
+        return false;
     }
 }

--- a/dspace-api/src/test/java/org/dspace/xmlworkflow/XmlWorkflowItemServiceIT.java
+++ b/dspace-api/src/test/java/org/dspace/xmlworkflow/XmlWorkflowItemServiceIT.java
@@ -1,0 +1,118 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xmlworkflow;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.EPersonBuilder;
+import org.dspace.builder.GroupBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
+import org.dspace.eperson.factory.EPersonServiceFactory;
+import org.dspace.eperson.service.GroupService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.xmlworkflow.factory.XmlWorkflowServiceFactory;
+import org.dspace.xmlworkflow.storedcomponents.service.XmlWorkflowItemService;
+import org.junit.Test;
+
+/**
+ * IT for {@link org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItemServiceImpl}
+ *
+ * @author K.Kaiser (TU Wien)
+ */
+public class XmlWorkflowItemServiceIT extends AbstractIntegrationTestWithDatabase {
+
+    protected XmlWorkflowItemService xmlWorkflowItemService = XmlWorkflowServiceFactory.getInstance()
+        .getXmlWorkflowItemService();
+    protected AuthorizeService authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
+    protected GroupService groupService = EPersonServiceFactory.getInstance().getGroupService();
+    protected ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+
+
+    @Test
+    public void isCollectionWithWorkflowConfiguredWithNewGroupName() throws Exception {
+        context.turnOffAuthorisationSystem();
+        EPerson submitter = EPersonBuilder.createEPerson(context).withEmail("submitter@example.org").build();
+        context.setCurrentUser(submitter);
+        Community community = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Collection colWithWorkflow = CollectionBuilder.createCollection(context, community)
+            .withName("Collection WITH workflow")
+            .withWorkflowGroup("editor", submitter)
+            .build();
+        context.restoreAuthSystemState();
+        String expectedGroupName = "COLLECTION_" + colWithWorkflow.getID() + "_WORKFLOW_ROLE_editor";
+        assertEquals("Expecting automatic group name", expectedGroupName,
+            colWithWorkflow.getWorkflowStep2(context).getName());
+        assertTrue("Workflow is configured with automatic group name and with a member",
+            xmlWorkflowItemService.isWorkflowConfigured(context, colWithWorkflow));
+    }
+
+    @Test
+    public void isCollectionWithWorkflowConfiguredWithOldGroupName() throws Exception {
+        context.turnOffAuthorisationSystem();
+        EPerson submitter = EPersonBuilder.createEPerson(context).withEmail("submitter@example.org").build();
+        context.setCurrentUser(submitter);
+        Group reviewer = GroupBuilder.createGroup(context).withName("Reviewers").addMember(submitter).build();
+        Community community = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Collection colWithWorkflow = CollectionBuilder.createCollection(context, community)
+            .withName("Collection WITH workflow")
+            .build();
+        colWithWorkflow.setWorkflowGroup(context, 1, reviewer);
+        context.restoreAuthSystemState();
+        assertEquals("Group name of Workflow Step 1 must be 'Reviewers'", "Reviewers",
+            colWithWorkflow.getWorkflowStep1(context).getName());
+        assertTrue("Workflow with group members must be considered a workflow",
+            xmlWorkflowItemService.isWorkflowConfigured(context, colWithWorkflow));
+    }
+
+    @Test
+    public void isCollectionWithoutWorkflowConfiguredWithEmptyGroup() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Group editor = GroupBuilder.createGroup(context).withName("Editors").build();
+        Community community = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Collection colWithWorkflow = CollectionBuilder.createCollection(context, community)
+            .withName("Collection WITH workflow, but empty group")
+            .build();
+        colWithWorkflow.setWorkflowGroup(context, 2, editor);
+        context.restoreAuthSystemState();
+        assertEquals("Group name of Workflow Step 2 must be 'Editors'", "Editors",
+            colWithWorkflow.getWorkflowStep2(context).getName());
+        assertFalse("Workflow without group members must not be considered a workflow",
+            xmlWorkflowItemService.isWorkflowConfigured(context, colWithWorkflow));
+    }
+
+    @Test
+    public void isCollectionWithoutWorkflowConfigured() {
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Collection colWithoutWorkflow = CollectionBuilder.createCollection(context, community)
+            .withName("Collection WITHOUT workflow")
+            .build();
+        context.restoreAuthSystemState();
+        assertFalse("Collection without a workflow configured",
+            xmlWorkflowItemService.isWorkflowConfigured(context, colWithoutWorkflow));
+    }
+}


### PR DESCRIPTION
## References

* Fixes #534 

## Description
XMLWorkflowItemService#isWorkflowConfigured uses a pattern-based approach for identifying potential groups by name that would allow to edit/review an item. This does not work for migrated configurations <7.x; they use a different pattern. Furthermore, the existence of a group with a matching name says nothing about whether a workflow is actually configured for the collection.

## Instructions for Reviewers

List of changes in this PR:
* First, the implementation was changed to get check for each possible workflow step of a collection a group is defined. If a group is defined and it's not empty, the check returns `true`.
* Second, the methods definition in the interface was changed, because the new implementation does not throw an exception.
* Third, a new integration test was implemented testing all possible configurations.
The new test is `XmlWorkflowItemServiceIT`. Run it:
```
mvn install -DskipIntegrationTests=false  -DfailIfNoTests=false -Dit.test=XmlWorkflowItemServiceIT
```

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
