### PR TITLE
DedupClient: change option description from 'search core' to 'dedup core'

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/batch/DedupClient.java
+++ b/dspace-api/src/main/java/org/dspace/app/batch/DedupClient.java
@@ -82,7 +82,7 @@ public class DedupClient {
 
         options.addOption(OptionBuilder.isRequired(false).withDescription("print this help message").create("h"));
 
-        options.addOption(OptionBuilder.isRequired(false).withDescription("optimize search core").create("o"));
+        options.addOption(OptionBuilder.isRequired(false).withDescription("optimize dedup core").create("o"));
 
         options.addOption("e", "readfile", true, "Read the identifier from a file");
 


### PR DESCRIPTION
## Description

This PR makes a small update to the command-line help description for the `-o` option in the `DedupClient` tool, clarifying that it optimizes the dedup core rather than the search core.