### PR TITLE
Fix fetching the correct sort field for relations

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfigurationUtilsService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/configuration/DiscoveryConfigurationUtilsService.java
@@ -20,6 +20,7 @@ import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
 import org.dspace.discovery.DiscoverQuery;
 import org.dspace.discovery.DiscoverResultIterator;
+import org.dspace.discovery.SearchService;
 import org.dspace.discovery.indexobject.IndexableItem;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -34,6 +35,8 @@ public class DiscoveryConfigurationUtilsService {
     private ItemService itemService;
     @Autowired
     private DiscoveryConfigurationService searchConfigurationService;
+    @Autowired
+    private SearchService solrService;
 
     public Iterator<Item> findByRelation(Context context, Item item, String relationName) {
         String entityType = itemService.getMetadataFirstValue(item, "dspace", "entity", "type", Item.ANY);
@@ -61,7 +64,7 @@ public class DiscoveryConfigurationUtilsService {
         } else {
             DiscoverySortFieldConfiguration sortField =
                 discoveryConfiguration.getSearchSortConfiguration().getDefaultSortField();
-            discoverQuery.setSortField(sortField.getMetadataField(),
+            discoverQuery.setSortField(solrService.toSortFieldIndex(sortField.getMetadataField(), sortField.getType()),
                                        DiscoverQuery.SORT_ORDER.valueOf(sortField.getDefaultSortOrder().name()));
         }
 


### PR DESCRIPTION
## Description
Having a relation defined in discovery.xml including a sort configuration, the Solr query might fail and no results are provided. This happens, if the metadata field used for sorting is a multi-valued field (e.g., "dc.date.issued").
Instead of adding the plain metadata field, the field type must be considered to get the correct Solr field used for sorting.

## References
* Fixes #547

## Instructions for Reviewers
* Steps to reproduce the behavior:

In discovery.xml in bean "relationAuthorResearchOutputsConfiguration" in the "searchSortConfiguration" set the defaultSortField to "sortDateIssuedDesc", add this sortfield also to the list of sortFields
Then load a researcher profile with the publications. There will not be any results; the layout of the page seems to be of DSpace Core.

List of changes in this PR:
* First, set the sortField by considering the field type

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
